### PR TITLE
Fix custom property detection across selectors and Svelte CSS

### DIFF
--- a/src/rules/no-unused-custom-properties/index.test.ts
+++ b/src/rules/no-unused-custom-properties/index.test.ts
@@ -25,6 +25,32 @@ afterEach(() => {
 
 const rule_name = 'projectwallace/no-unused-custom-properties'
 
+test('should not error when vars are declared in one selector and used in another', async () => {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: true,
+		},
+	}
+
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `
+			nav {
+				--py: 0.35rem;
+				--px: var(--space-3);
+			}
+			.compact {
+				padding: var(--py) var(--px);
+			}`,
+		config,
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
 test('should not error on a single used custom property', async () => {
 	const config = {
 		plugins: [plugin],

--- a/src/utils/custom-properties.test.ts
+++ b/src/utils/custom-properties.test.ts
@@ -93,3 +93,30 @@ test('collect_var_usages: finds multiple var() usages', () => {
 	expect(a?.has_fallback).toBe(false)
 	expect(b?.has_fallback).toBe(true)
 })
+
+test('collect_var_usages: finds var() usages across different selectors', () => {
+	const root = parse(
+		'nav { --py: 0.35rem; --px: var(--space-3); } .compact { padding: var(--py) var(--px); }',
+	)
+	const usages = collect_var_usages(root)
+	const names = usages.map((u) => u.name)
+	expect(names).toContain('--py')
+	expect(names).toContain('--px')
+	expect(names).toContain('--space-3')
+})
+
+test('collect_var_usages: finds var() usages even when input.css offsets do not match (Svelte embedded CSS)', () => {
+	// Simulate what happens with Svelte: stylelint extracts CSS from <style>...</style>
+	// but root.source.input.css may contain the full Svelte file while
+	// declaration.source offsets are relative to the extracted CSS only.
+	// The bug: substring(start_offset, end_offset) on the full file extracts wrong text.
+	const css = '.compact { padding: var(--py) var(--px); }'
+	const root = parse(css)
+	// Override input.css to simulate the Svelte mismatch (prepend non-CSS content)
+	;(root.source!.input as unknown as { css: string }).css =
+		'<script>const x = 1</script><style>' + css + '</style>'
+	const usages = collect_var_usages(root)
+	const names = usages.map((u) => u.name)
+	expect(names).toContain('--py')
+	expect(names).toContain('--px')
+})

--- a/src/utils/custom-properties.ts
+++ b/src/utils/custom-properties.ts
@@ -31,10 +31,7 @@ export function collect_var_usages(root: Root): VarUsage[] {
 	const usages: VarUsage[] = []
 
 	root.walkDecls(function (declaration) {
-		const decl_source = root.source!.input.css.substring(
-			declaration.source!.start!.offset,
-			declaration.source!.end!.offset,
-		)
+		const decl_source = `${declaration.prop}: ${declaration.value}`
 		const parsed = parse_declaration(decl_source)
 
 		walk(parsed, (node) => {


### PR DESCRIPTION
## Summary
Fixed a bug in custom property usage detection that prevented the `no-unused-custom-properties` rule from correctly identifying variable usages across different selectors and in Svelte embedded CSS files.

## Key Changes
- **Fixed offset-based CSS extraction**: Changed from using `root.source.input.css.substring()` with declaration offsets to directly constructing the declaration string from `declaration.prop` and `declaration.value`. This eliminates issues when source offsets don't match the actual CSS content (common in Svelte where offsets are relative to extracted CSS but `input.css` contains the full file).
- **Added test coverage**: Added two new test cases to `collect_var_usages` tests:
  - Validates detection of var usages across different selectors
  - Validates detection works correctly when input.css offsets are misaligned (Svelte scenario)
- **Added integration test**: Added a stylelint rule test to ensure variables declared in one selector and used in another are not flagged as unused.

## Implementation Details
The root cause was that the code attempted to extract declaration text by slicing `root.source.input.css` using offsets from `declaration.source`. In Svelte files, stylelint extracts CSS from `<style>` tags, but `input.css` may contain the entire Svelte file while declaration offsets are relative only to the extracted CSS. This mismatch caused incorrect substring extraction.

The fix is simpler and more reliable: reconstruct the declaration directly from the parsed AST properties (`prop` and `value`), which are already correctly parsed and don't depend on source offsets.

https://claude.ai/code/session_01AM3KYry2PrxVWHf8UV56DA