### PR TITLE
Fix declaration counting in nested rules and at-rules

### DIFF
--- a/src/rules/max-average-declarations-per-rule/index.test.ts
+++ b/src/rules/max-average-declarations-per-rule/index.test.ts
@@ -67,3 +67,45 @@ test('should error when average declarations per rule exceeds the limit', async 
 	})
 	expect(warnings[0].text).toContain('greater than the allowed 1')
 })
+
+test('should not count declarations from nested rules', async () => {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: 2,
+		},
+	}
+
+	// outer rule: 1 direct decl, inner rule: 2 direct decls → average = (1 + 2) / 2 = 1.5
+	// old buggy code would count: outer = 3, inner = 2 → average = 2.5
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `a { color: red; & .foo { font-size: 1em; margin: 0; } }`,
+		config,
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not count declarations from nested atrules', async () => {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: 1,
+		},
+	}
+
+	// outer rule has 1 direct decl; declarations inside @supports are not counted towards it
+	// old buggy code would count color + font-size + margin = 3 for the outer rule
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `a { color: red; @supports (display: grid) { font-size: 1em; margin: 0; } }`,
+		config,
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})

--- a/src/rules/max-average-declarations-per-rule/index.ts
+++ b/src/rules/max-average-declarations-per-rule/index.ts
@@ -1,5 +1,8 @@
 import stylelint from 'stylelint'
 import type { Root } from 'postcss'
+import { STYLE_RULE, AT_RULE, DECLARATION } from '@projectwallace/css-parser/nodes'
+import { walk, SKIP } from '@projectwallace/css-parser/walker'
+import { parse } from '@projectwallace/css-parser/parse'
 
 const { createPlugin, utils } = stylelint
 
@@ -25,16 +28,24 @@ const ruleFunction = (primaryOption: number) => {
 			return
 		}
 
+		const css = root.toString()
+		const ast = parse(css, { parse_selectors: false, parse_values: false })
 		let total_declarations = 0
 		let rule_count = 0
 
-		root.walkRules((rule) => {
-			let decl_count = 0
-			rule.walkDecls(() => {
-				decl_count++
-			})
-			total_declarations += decl_count
+		walk(ast, (node) => {
+			if (node.type !== STYLE_RULE) return
+
 			rule_count++
+			let decl_count = 0
+
+			walk(node, (child, child_depth) => {
+				if (child_depth === 0) return
+				if (child.type === DECLARATION) decl_count++
+				if (child.type === STYLE_RULE || child.type === AT_RULE) return SKIP
+			})
+
+			total_declarations += decl_count
 		})
 
 		if (rule_count === 0) return


### PR DESCRIPTION
## Summary
Fixed a bug in the `max-average-declarations-per-rule` rule where declarations inside nested rules and at-rules were being incorrectly counted towards the parent rule's declaration count.

## Key Changes
- Migrated from PostCSS's `walkRules` and `walkDecls` to `@projectwallace/css-parser` for more precise AST traversal
- Implemented depth-aware walking to only count direct declarations (depth > 0 children) of each rule
- Added logic to skip traversing into nested style rules and at-rules using the `SKIP` control flow
- Added test cases to verify declarations in nested rules and nested at-rules are not counted towards parent rules

## Implementation Details
- The fix uses `@projectwallace/css-parser`'s `walk` function with depth tracking to distinguish between direct children and nested descendants
- When encountering nested style rules or at-rules, the walker skips their subtrees to prevent double-counting
- This ensures the average calculation correctly reflects only direct declarations per rule, not inherited ones from nested structures

https://claude.ai/code/session_016AeFwSgMJS3NZCwVRvbcyT