### PR TITLE
Simplify tsdown entry configuration with glob pattern

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,11 +2,7 @@ import { defineConfig } from 'tsdown'
 import { codecovRollupPlugin } from '@codecov/rollup-plugin'
 
 export default defineConfig({
-	entry: {
-		index: './src/index.ts',
-		'configs/recommended': './src/configs/recommended.ts',
-		'configs/performance': './src/configs/performance.ts',
-	},
+	entry: ['./src/index.ts', './src/configs/*.ts'],
 	format: ['esm'],
 	platform: 'node',
 	dts: true,


### PR DESCRIPTION
## Summary
Refactored the tsdown build configuration to use a glob pattern for entry points instead of explicitly listing each config file.

## Key Changes
- Replaced explicit entry point object with array-based glob pattern
- Changed from:
  - `index: './src/index.ts'`
  - `'configs/recommended': './src/configs/recommended.ts'`
  - `'configs/performance': './src/configs/performance.ts'`
- To: `['./src/index.ts', './src/configs/*.ts']`

## Benefits
- Reduces configuration boilerplate and maintenance overhead
- Automatically includes any new config files added to `src/configs/` without requiring manual updates
- Maintains the same build output while improving configuration clarity

https://claude.ai/code/session_01BVWxNpZ11hfCUmUn6o7XGi