### PR TITLE
Extract allowList pattern matching into reusable utility

### DIFF
--- a/src/rules/no-undeclared-container-names/index.ts
+++ b/src/rules/no-undeclared-container-names/index.ts
@@ -4,6 +4,7 @@ import {
 	collect_declared_container_names,
 	collect_container_name_usages,
 } from '../../utils/container-names.js'
+import { isAllowed } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -39,14 +40,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 		for (const usage of usages) {
 			if (declared_names.has(usage.name)) continue
 
-			if (secondaryOptions?.allowList) {
-				const allowed = secondaryOptions.allowList.some(
-					(pattern) =>
-						(typeof pattern === 'string' && pattern === usage.name) ||
-						(pattern instanceof RegExp && pattern.test(usage.name)),
-				)
-				if (allowed) continue
-			}
+			if (secondaryOptions?.allowList && isAllowed(usage.name, secondaryOptions.allowList)) continue
 
 			utils.report({
 				result,

--- a/src/rules/no-unknown-custom-property/index.ts
+++ b/src/rules/no-unknown-custom-property/index.ts
@@ -3,6 +3,7 @@ import type { Root } from 'postcss'
 import { collect_declared_properties, collect_var_usages } from '../../utils/custom-properties.js'
 import { collect_declarations_from_files } from '../../utils/import-from.js'
 import type { ImportFrom } from '../../utils/import-from.js'
+import { isAllowed } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -45,14 +46,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 			if (declared_properties.has(usage.name)) continue
 			if (imported_properties?.has(usage.name)) continue
 			if (secondaryOptions?.allowFallback && usage.has_fallback) continue
-			if (secondaryOptions?.allowList) {
-				const allowed = secondaryOptions.allowList.some(
-					(pattern) =>
-						(typeof pattern === 'string' && pattern === usage.name) ||
-						(pattern instanceof RegExp && pattern.test(usage.name)),
-				)
-				if (allowed) continue
-			}
+			if (secondaryOptions?.allowList && isAllowed(usage.name, secondaryOptions.allowList)) continue
 
 			utils.report({
 				result,

--- a/src/rules/no-unused-container-names/index.ts
+++ b/src/rules/no-unused-container-names/index.ts
@@ -4,6 +4,7 @@ import {
 	collect_declared_container_names,
 	collect_container_name_usages,
 } from '../../utils/container-names.js'
+import { isAllowed } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -39,14 +40,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 		for (const [name, node] of declared_names) {
 			if (used_names.has(name)) continue
 
-			if (secondaryOptions?.allowList) {
-				const allowed = secondaryOptions.allowList.some(
-					(pattern) =>
-						(typeof pattern === 'string' && pattern === name) ||
-						(pattern instanceof RegExp && pattern.test(name)),
-				)
-				if (allowed) continue
-			}
+			if (secondaryOptions?.allowList && isAllowed(name, secondaryOptions.allowList)) continue
 
 			utils.report({
 				result,

--- a/src/rules/no-useless-custom-property-assignment/index.ts
+++ b/src/rules/no-useless-custom-property-assignment/index.ts
@@ -1,5 +1,6 @@
 import stylelint from 'stylelint'
 import type { Root } from 'postcss'
+import { isAllowed } from '../../utils/allow-list.js'
 import { DECLARATION, FUNCTION, IDENTIFIER } from '@projectwallace/css-parser/nodes'
 import { walk } from '@projectwallace/css-parser/walker'
 import { parse } from '@projectwallace/css-parser/parse'
@@ -45,14 +46,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 			const prop = node.property
 			if (!prop?.startsWith('--')) return
 
-			if (secondaryOptions?.allowList) {
-				const allowed = secondaryOptions.allowList.some(
-					(pattern) =>
-						(typeof pattern === 'string' && pattern === prop) ||
-						(pattern instanceof RegExp && pattern.test(prop)),
-				)
-				if (allowed) return
-			}
+			if (secondaryOptions?.allowList && isAllowed(prop, secondaryOptions.allowList)) return
 
 			let reported = false
 

--- a/src/utils/allow-list.ts
+++ b/src/utils/allow-list.ts
@@ -1,0 +1,11 @@
+/**
+ * Check if a given value matches any pattern in an allowList.
+ * Each pattern can be an exact string or a RegExp.
+ */
+export function isAllowed(value: string, allowList: Array<string | RegExp>): boolean {
+	return allowList.some(
+		(pattern) =>
+			(typeof pattern === 'string' && pattern === value) ||
+			(pattern instanceof RegExp && pattern.test(value)),
+	)
+}


### PR DESCRIPTION
## Summary
This PR refactors duplicate allowList pattern matching logic across multiple rules into a shared utility function, improving code maintainability and consistency.

## Key Changes
- Created new `src/utils/allow-list.ts` with `isAllowed()` utility function that checks if a value matches any pattern in an allowList (supporting both exact string matches and RegExp patterns)
- Replaced identical pattern matching logic in 4 rules with calls to the new utility:
  - `no-undeclared-container-names`
  - `no-unknown-custom-property`
  - `no-unused-container-names`
  - `no-useless-custom-property-assignment`

## Implementation Details
The `isAllowed()` function encapsulates the pattern matching logic that was previously duplicated across rules:
- Accepts a string value and an array of patterns (string or RegExp)
- Returns true if the value matches any pattern (exact string equality or RegExp test)
- Reduces code duplication and makes future allowList changes easier to maintain

https://claude.ai/code/session_01TFYTQckwbyu3Xffc3wAt8o