### PR TITLE
perf: replace Wallace css parser/walker with PostCSS native APIs where possible

### DIFF
--- a/src/rules/max-average-declarations-per-rule/index.ts
+++ b/src/rules/max-average-declarations-per-rule/index.ts
@@ -1,8 +1,5 @@
 import stylelint from 'stylelint'
 import type { Root } from 'postcss'
-import { STYLE_RULE, AT_RULE, DECLARATION } from '@projectwallace/css-parser/nodes'
-import { walk, SKIP } from '@projectwallace/css-parser/walker'
-import { parse } from '@projectwallace/css-parser/parse'
 
 const { createPlugin, utils } = stylelint
 
@@ -28,24 +25,14 @@ const ruleFunction = (primaryOption: number) => {
 			return
 		}
 
-		const css = root.toString()
-		const ast = parse(css, { parse_selectors: false, parse_values: false })
 		let total_declarations = 0
 		let rule_count = 0
 
-		walk(ast, (node) => {
-			if (node.type !== STYLE_RULE) return
-
+		root.walkRules((rule) => {
 			rule_count++
-			let decl_count = 0
-
-			walk(node, (child, child_depth) => {
-				if (child_depth === 0) return
-				if (child.type === DECLARATION) decl_count++
-				if (child.type === STYLE_RULE || child.type === AT_RULE) return SKIP
+			rule.each((node) => {
+				if (node.type === 'decl') total_declarations++
 			})
-
-			total_declarations += decl_count
 		})
 
 		if (rule_count === 0) return

--- a/src/rules/max-important-ratio/index.ts
+++ b/src/rules/max-important-ratio/index.ts
@@ -1,6 +1,5 @@
 import stylelint from 'stylelint'
 import type { Root } from 'postcss'
-import { parse_declaration } from '@projectwallace/css-parser/parse-declaration'
 
 const { createPlugin, utils } = stylelint
 
@@ -31,19 +30,12 @@ const ruleFunction = (primaryOption: number) => {
 			return
 		}
 
-		const css = root.source!.input.css
 		let total_declarations = 0
 		let important_declarations = 0
 
 		root.walkDecls((declaration) => {
-			const decl_source = css.substring(
-				declaration.source!.start!.offset,
-				declaration.source!.end!.offset,
-			)
-			const parsed = parse_declaration(decl_source)
-
 			total_declarations++
-			if (parsed.is_important) {
+			if (declaration.important) {
 				important_declarations++
 			}
 		})

--- a/src/rules/max-selector-complexity/index.ts
+++ b/src/rules/max-selector-complexity/index.ts
@@ -1,9 +1,6 @@
 import stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_selector } from '@projectwallace/css-parser/parse-selector'
-import { STYLE_RULE } from '@projectwallace/css-parser/nodes'
-import { walk } from '@projectwallace/css-parser/walker'
-import { parse } from '@projectwallace/css-parser/parse'
 import { selectorComplexity } from '@projectwallace/css-analyzer'
 
 const { createPlugin, utils } = stylelint
@@ -30,17 +27,8 @@ const ruleFunction = (primaryOption: number) => {
 			return
 		}
 
-		const css = root.toString()
-		const parsed = parse(css, {
-			parse_atrule_preludes: false,
-			parse_values: false,
-		})
-		const line_offset = (root.source?.start?.line ?? 1) - 1
-
-		walk(parsed, (node) => {
-			if (node.type !== STYLE_RULE) return
-
-			const selector_text = node.prelude?.text ?? ''
+		root.walkRules((rule) => {
+			const selector_text = rule.selector
 			if (!selector_text.trim()) return
 
 			const selector_list = parse_selector(selector_text)
@@ -52,9 +40,7 @@ const ruleFunction = (primaryOption: number) => {
 				if (complexity > primaryOption) {
 					utils.report({
 						message: messages.rejected(stringified, complexity, primaryOption),
-						node: root,
-						start: { line: node.line + line_offset, column: node.column },
-						end: { line: node.line + line_offset, column: node.column + node.length },
+						node: rule,
 						result,
 						ruleName: rule_name,
 					})

--- a/src/rules/no-unused-layers/index.ts
+++ b/src/rules/no-unused-layers/index.ts
@@ -1,8 +1,6 @@
 import stylelint from 'stylelint'
-import type { Root } from 'postcss'
-import { AT_RULE } from '@projectwallace/css-parser/nodes'
-import { walk } from '@projectwallace/css-parser/walker'
-import { parse } from '@projectwallace/css-parser/parse'
+import type { Root, AtRule } from 'postcss'
+import { isAllowed } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -31,63 +29,39 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 			return
 		}
 
-		const css = root.toString()
-		const parsed = parse(css, {
-			parse_selectors: false,
-			parse_values: false,
-		})
-		const line_offset = (root.source?.start?.line ?? 1) - 1
-
-		const declared_layers = new Map<string, { line: number; column: number }>()
+		const declared_layers = new Map<string, AtRule>()
 		const defined_layers = new Set<string>()
 
-		walk(parsed, (node) => {
-			if (node.type !== AT_RULE) return
-			if (node.name !== 'layer') return
-
-			if (node.has_block) {
+		root.walkAtRules('layer', (atRule) => {
+			if (atRule.nodes !== undefined) {
 				// Block rule: @layer name { ... }
-				const name = node.prelude?.text.trim()
+				const name = atRule.params.trim()
 				if (name) {
 					defined_layers.add(name)
 				}
 			} else {
 				// Statement: @layer name; or @layer a, b, c;
-				const prelude_text = node.prelude?.text ?? ''
-				const names = prelude_text
+				const names = atRule.params
 					.split(',')
 					.map((n) => n.trim())
 					.filter(Boolean)
 				for (const name of names) {
 					if (!declared_layers.has(name)) {
-						declared_layers.set(name, { line: node.line, column: node.column })
+						declared_layers.set(name, atRule)
 					}
 				}
 			}
 		})
 
-		for (const [layer, pos] of declared_layers) {
+		for (const [layer, node] of declared_layers) {
 			if (defined_layers.has(layer)) continue
-
-			if (secondaryOptions?.allowlist) {
-				const allowed = secondaryOptions.allowlist.some(
-					(pattern) =>
-						(typeof pattern === 'string' && pattern === layer) ||
-						(pattern instanceof RegExp && pattern.test(layer)),
-				)
-				if (allowed) continue
-			}
+			if (secondaryOptions?.allowlist && isAllowed(layer, secondaryOptions.allowlist)) continue
 
 			utils.report({
 				result,
 				ruleName: rule_name,
 				message: messages.rejected(layer),
-				node: root,
-				start: { line: pos.line + line_offset, column: pos.column },
-				end: {
-					line: pos.line + line_offset,
-					column: pos.column + '@layer'.length,
-				},
+				node,
 				word: layer,
 			})
 		}


### PR DESCRIPTION
## Summary
Refactored multiple stylelint rules to use PostCSS native APIs instead of the `@projectwallace/css-parser` library, simplifying the codebase and improving maintainability.

## Key Changes
- **no-unused-layers**: Replaced custom parser with `root.walkAtRules('layer')`, simplified position tracking by using AtRule nodes directly, and extracted allowlist logic to `isAllowed()` utility function
- **max-selector-complexity**: Replaced custom parser with `root.walkRules()` for iterating style rules, removed manual line offset calculations
- **max-average-declarations-per-rule**: Replaced custom parser with `root.walkRules()` and `rule.each()` for traversing declarations, simplified node type checking
- **max-important-ratio**: Removed custom declaration parser, now uses PostCSS's native `declaration.important` property instead of parsing declaration source text

## Implementation Details
- Removed dependencies on `@projectwallace/css-parser` modules: `parse`, `walk`, `nodes` constants
- Eliminated manual line offset calculations (`root.source?.start?.line`) by using PostCSS node objects directly for reporting
- Simplified allowlist checking in no-unused-layers by delegating to extracted utility function
- All rules now leverage PostCSS's built-in traversal methods and node properties, reducing code complexity and improving consistency with stylelint patterns

https://claude.ai/code/session_01VsxyyE2S6uMjaSkPKRej5u