### PR TITLE
Add max-unique-colors rule to enforce color palette limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Alternatively, add the plugin and configure rules individually in your stylelint
 		"projectwallace/max-lines-of-code": 200,
 		"projectwallace/max-selector-complexity": 5,
 		"projectwallace/max-selectors-per-rule": 10,
+		"projectwallace/max-unique-colors": 5,
 		"projectwallace/max-unique-units": 5,
 		"projectwallace/min-declaration-uniqueness-ratio": 0.5,
 		"projectwallace/min-selector-uniqueness-ratio": 0.66,
@@ -97,6 +98,7 @@ Alternatively, add the plugin and configure rules individually in your stylelint
 | [max-lines-of-code](src/rules/max-lines-of-code/README.md)                                         | Prevent a stylesheet from exceeding a predefined number of lines of code   |
 | [max-selector-complexity](src/rules/max-selector-complexity/README.md)                             | Prevent selector complexity from going over a predefined maximum           |
 | [max-selectors-per-rule](src/rules/max-selectors-per-rule/README.md)                               | Limit the number of selectors in a single rule                             |
+| [max-unique-colors](src/rules/max-unique-colors/README.md)                                         | Limit the number of unique color values used across the stylesheet         |
 | [max-unique-units](src/rules/max-unique-units/README.md)                                           | Limit the number of unique CSS units used across the stylesheet            |
 | [min-declaration-uniqueness-ratio](src/rules/min-declaration-uniqueness-ratio/README.md)           | Enforce a minimum ratio of unique declarations across the stylesheet       |
 | [min-selector-uniqueness-ratio](src/rules/min-selector-uniqueness-ratio/README.md)                 | Enforce a minimum ratio of unique selectors across the stylesheet          |

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -24,6 +24,7 @@ export default {
 		'projectwallace/max-average-declarations-per-rule': 6,
 		'projectwallace/max-average-selector-complexity': 3,
 		'projectwallace/max-important-ratio': 0.1,
+		'projectwallace/max-unique-colors': 10,
 		'projectwallace/max-unique-units': 10,
 		'projectwallace/min-selector-uniqueness-ratio': 0.66,
 		'projectwallace/min-declaration-uniqueness-ratio': 0.5,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -37,5 +37,6 @@ test('exports an array of stylelint rules', () => {
 		'projectwallace/max-declarations-per-rule',
 		'projectwallace/no-invalid-z-index',
 		'projectwallace/no-property-shorthand',
+		'projectwallace/max-unique-colors',
 	])
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import max_selectors_per_rule from './rules/max-selectors-per-rule/index.js'
 import max_declarations_per_rule from './rules/max-declarations-per-rule/index.js'
 import no_invalid_z_index from './rules/no-invalid-z-index/index.js'
 import no_property_shorthand from './rules/no-property-shorthand/index.js'
+import max_unique_colors from './rules/max-unique-colors/index.js'
 
 const plugins: stylelint.Plugin[] = [
 	max_selector_complexity,
@@ -59,6 +60,7 @@ const plugins: stylelint.Plugin[] = [
 	max_declarations_per_rule,
 	no_invalid_z_index,
 	no_property_shorthand,
+	max_unique_colors,
 ]
 
 export default plugins

--- a/src/rules/max-unique-colors/README.md
+++ b/src/rules/max-unique-colors/README.md
@@ -1,0 +1,112 @@
+# Max unique colors
+
+Limit the number of unique color values used across the stylesheet.
+
+<!-- prettier-ignore -->
+```css
+a { color: red; }
+/*         ↑
+*   "red" counts as a unique color */
+```
+
+Using too many different colors can indicate an inconsistent design system. This rule helps enforce a controlled color palette.
+
+A unique color is counted by its exact string representation. Each of the following is detected as a color:
+
+- Named colors: `red`, `blue`, `transparent`, `currentColor`, etc.
+- Hex colors: `#f00`, `#ff0000`, `#ff000080`, etc.
+- Color functions: `rgb()`, `hsl()`, `hwb()`, `lab()`, `lch()`, `oklab()`, `oklch()`, `color()`, `color-mix()`, `light-dark()`, etc.
+- `var()` references to custom properties declared with `@property { syntax: '<color>' }`
+
+> **Note**: Colors are compared by their exact string value. `#f00` and `#ff0000` are treated as two distinct colors even though they represent the same visual color.
+
+## Options
+
+### `Number` (required)
+
+The maximum number of unique color values allowed. Must be a positive integer.
+
+Given:
+
+`3`
+
+the following are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { color: red; }
+b { color: blue; }
+c { color: green; }
+d { color: yellow; }
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { color: red; }
+b { background-color: red; }
+c { border-color: blue; }
+```
+
+### `ignore` (optional)
+
+Type: `Array<string | RegExp>`
+
+A list of color values to exclude from the count. Each entry can be an exact string or a regular expression.
+
+> **Note**: String patterns are matched against the exact string value of the detected color (preserving original casing).
+
+Given:
+
+`[2, { "ignore": ["transparent", "currentColor"] }]`
+
+the following are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a {
+  color: red;
+  background-color: transparent;
+  border-color: currentColor;
+  outline-color: blue;
+}
+```
+
+## `var()` and `@property`
+
+When a custom property is declared with `@property { syntax: '<color>' }`, any `var()` referencing it is recognised as a color value and counted as a unique color.
+
+<!-- prettier-ignore -->
+```css
+@property --brand-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #0070f3;
+}
+
+a { color: var(--brand-color); }
+b { color: var(--brand-color); }  /* same var() expression → still 1 unique color */
+```
+
+If a `var()` has a fallback value, the fallback colors are counted separately:
+
+<!-- prettier-ignore -->
+```css
+@property --brand-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: blue;
+}
+
+/* var(--brand-color, red) counts as 2 colors: the var() expression and "red" */
+a { color: var(--brand-color, red); }
+```
+
+Without a `@property` declaration, `var()` is not counted (the actual color value is unknown at lint time), but any fallback values are still evaluated:
+
+<!-- prettier-ignore -->
+```css
+/* var(--unknown) → not counted; "blue" fallback → counted as 1 color */
+a { color: var(--unknown, blue); }
+```

--- a/src/rules/max-unique-colors/index.test.ts
+++ b/src/rules/max-unique-colors/index.test.ts
@@ -1,0 +1,563 @@
+import stylelint from 'stylelint'
+import { test, expect } from 'vitest'
+import plugin from './index.js'
+
+const rule_name = 'projectwallace/max-unique-colors'
+
+async function lint(code: string, primaryOption: unknown, secondaryOptions?: unknown) {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: secondaryOptions !== undefined ? [primaryOption, secondaryOptions] : primaryOption,
+		},
+	}
+
+	const {
+		results: [result],
+	} = await stylelint.lint({ code, config })
+
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Option validation
+// ---------------------------------------------------------------------------
+
+test('should not run when config is negative', async () => {
+	// -1 passes the Number type check but fails the > 0 guard → no lint errors
+	const { warnings, errored } = await lint(`a { color: red; }`, -1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not run when config is a float', async () => {
+	const { warnings, errored } = await lint(`a { color: red; }`, 1.5)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not run when rule is disabled with null', async () => {
+	const { warnings, errored } = await lint(`a { color: red; }`, null)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+// ---------------------------------------------------------------------------
+// No violation — basic cases
+// ---------------------------------------------------------------------------
+
+test('should not error when there are no colors', async () => {
+	const { warnings, errored } = await lint(`a { font-size: 16px; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not error when unique colors are within the limit', async () => {
+	const { warnings, errored } = await lint(`a { color: red; background-color: blue; }`, 2)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not error when the same named color is reused', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: red; } b { background-color: red; border-color: red; }`,
+		1,
+	)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not error when the same hex color is reused', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: #fff; } b { background-color: #fff; }`,
+		1,
+	)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+// ---------------------------------------------------------------------------
+// Violations
+// ---------------------------------------------------------------------------
+
+test('should error when unique colors exceed the limit', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: red; background-color: blue; border-color: green; }`,
+		2,
+	)
+	expect(errored).toBe(true)
+	expect(warnings).toHaveLength(1)
+	expect(warnings[0]).toMatchObject({ rule: rule_name, severity: 'error' })
+	expect(warnings[0].text).toContain('Found 3 unique colors')
+	expect(warnings[0].text).toContain('exceeds the maximum of 2')
+})
+
+test('should error at the stylesheet level (node is root)', async () => {
+	const { warnings } = await lint(`a { color: red; } b { color: blue; }`, 1)
+	expect(warnings).toHaveLength(1)
+	// The warning should be on the root node (line 1, column 1)
+	expect(warnings[0].line).toBe(1)
+})
+
+// ---------------------------------------------------------------------------
+// Named colors (case-insensitivity of detection, case-sensitivity for uniqueness)
+// ---------------------------------------------------------------------------
+
+test('should recognise named colors case-insensitively as colors', async () => {
+	// Both 'Red' and 'RED' are detected as named colors, but kept as-is for uniqueness
+	const { warnings, errored } = await lint(`a { color: Red; } b { color: RED; }`, 1)
+	// Red ≠ RED → 2 unique colors → violation
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+test('should treat the same color casing as one unique color', async () => {
+	const { warnings, errored } = await lint(`a { color: red; } b { color: red; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise transparent as a color', async () => {
+	const { warnings, errored } = await lint(`a { background-color: transparent; color: red; }`, 1)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+test('should recognise currentColor as a color', async () => {
+	const { warnings, errored } = await lint(
+		`a { border-color: currentColor; color: red; }`,
+		1,
+	)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+// ---------------------------------------------------------------------------
+// Hex colors
+// ---------------------------------------------------------------------------
+
+test('should recognise 3-digit hex colors', async () => {
+	const { warnings, errored } = await lint(`a { color: #f00; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise 4-digit hex colors (with alpha)', async () => {
+	const { warnings, errored } = await lint(`a { color: #f00f; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise 6-digit hex colors', async () => {
+	const { warnings, errored } = await lint(`a { color: #ff0000; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise 8-digit hex colors (with alpha)', async () => {
+	const { warnings, errored } = await lint(`a { color: #ff000080; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should treat different hex strings as different unique colors', async () => {
+	// #f00 and #ff0000 both visually represent red but are different strings
+	const { warnings, errored } = await lint(`a { color: #f00; background-color: #ff0000; }`, 1)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+test('should preserve hex casing for uniqueness', async () => {
+	// #FFF and #fff are treated as different values
+	const { warnings, errored } = await lint(`a { color: #FFF; } b { color: #fff; }`, 1)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+// ---------------------------------------------------------------------------
+// Color functions
+// ---------------------------------------------------------------------------
+
+test('should recognise rgb() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: rgb(255, 0, 0); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise rgba() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: rgba(255, 0, 0, 0.5); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise hsl() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: hsl(120deg 100% 50%); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise hsla() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: hsla(120deg 100% 50% / 0.5); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise hwb() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: hwb(120 0% 0%); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise lab() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: lab(50% 40 59); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise lch() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: lch(50% 73 39); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise oklab() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: oklab(0.5 0.1 -0.1); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise oklch() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: oklch(0.5 0.2 120); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise color() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: color(display-p3 1 0 0); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should recognise color-mix() as a color', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: color-mix(in srgb, #fff 50%, #000); }`,
+		1,
+	)
+	// color-mix() itself is 1 unique color; #fff and #000 inside it are also counted
+	// → 3 unique colors total
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 3 unique colors')
+})
+
+test('should recognise light-dark() as a color', async () => {
+	const { warnings, errored } = await lint(`a { color: light-dark(white, black); }`, 1)
+	// light-dark() itself is counted, plus white and black inside → 3 unique colors
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 3 unique colors')
+})
+
+// ---------------------------------------------------------------------------
+// Colors in shorthand and gradient properties
+// ---------------------------------------------------------------------------
+
+test('should detect colors in background shorthand', async () => {
+	const { warnings, errored } = await lint(`a { background: red url(img.png) no-repeat; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should detect colors in border shorthand', async () => {
+	const { warnings, errored } = await lint(`a { border: 1px solid blue; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should detect colors in box-shadow', async () => {
+	const { warnings, errored } = await lint(
+		`a { box-shadow: 0 0 10px red, 0 0 20px blue; }`,
+		1,
+	)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+test('should detect colors in text-shadow', async () => {
+	const { warnings, errored } = await lint(`a { text-shadow: 1px 1px 2px black; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should detect named colors inside linear-gradient()', async () => {
+	const { warnings, errored } = await lint(
+		`a { background-image: linear-gradient(red, blue); }`,
+		1,
+	)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+test('should detect hex colors inside radial-gradient()', async () => {
+	const { warnings, errored } = await lint(
+		`a { background-image: radial-gradient(#fff, #000); }`,
+		1,
+	)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+test('should detect colors in SVG fill property', async () => {
+	const { warnings, errored } = await lint(`circle { fill: red; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should detect colors in SVG stroke property', async () => {
+	const { warnings, errored } = await lint(`circle { stroke: blue; }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not count non-color properties', async () => {
+	// font-size, margin, padding etc. should not contribute to color count
+	const { warnings, errored } = await lint(
+		`a { font-size: 16px; margin: 0; padding: 10px; }`,
+		1,
+	)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+// ---------------------------------------------------------------------------
+// var() — without @property
+// ---------------------------------------------------------------------------
+
+test('should not count var() when the custom property is not @property <color>', async () => {
+	// Without @property, we cannot know whether the var() is a color
+	const { warnings, errored } = await lint(`a { color: var(--my-color); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should count named-color fallback inside var() even without @property', async () => {
+	const { warnings, errored } = await lint(`a { color: var(--undefined, red); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should count multiple fallback colors from different var() declarations', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: var(--a, red); background-color: var(--b, blue); }`,
+		1,
+	)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+test('should count hex fallback inside var() without @property', async () => {
+	const { warnings, errored } = await lint(`a { color: var(--unknown, #ff0000); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should count color-function fallback inside var() without @property', async () => {
+	const { warnings, errored } = await lint(`a { color: var(--unknown, rgb(255, 0, 0)); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should count named color from nested var() fallback', async () => {
+	// var(--a, var(--b, blue)) — blue is the deepest fallback
+	const { warnings, errored } = await lint(`a { color: var(--a, var(--b, blue)); }`, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+// ---------------------------------------------------------------------------
+// var() — with @property { syntax: '<color>' }
+// ---------------------------------------------------------------------------
+
+test('should count var() referencing a @property <color> custom property', async () => {
+	const code = `
+		@property --brand-color {
+			syntax: '<color>';
+			inherits: false;
+			initial-value: red;
+		}
+		a { color: var(--brand-color); }
+	`
+	const { warnings, errored } = await lint(code, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should count var() as a unique color when it is a @property <color>', async () => {
+	const code = `
+		@property --brand-color {
+			syntax: '<color>';
+			inherits: false;
+			initial-value: red;
+		}
+		@property --accent-color {
+			syntax: '<color>';
+			inherits: false;
+			initial-value: blue;
+		}
+		a { color: var(--brand-color); }
+		b { color: var(--accent-color); }
+	`
+	const { warnings, errored } = await lint(code, 1)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+test('should count the var() expression AND fallback colors separately', async () => {
+	// var(--brand-color, red): the var() is 1 color; "red" fallback is another
+	const code = `
+		@property --brand-color {
+			syntax: '<color>';
+			inherits: false;
+			initial-value: blue;
+		}
+		a { color: var(--brand-color, red); }
+	`
+	const { warnings, errored } = await lint(code, 1)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+test('should not count var() of a @property that does not have syntax <color>', async () => {
+	const code = `
+		@property --size {
+			syntax: '<length>';
+			inherits: false;
+			initial-value: 0px;
+		}
+		a { width: var(--size); }
+	`
+	const { warnings, errored } = await lint(code, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should handle @property with single-quoted syntax value', async () => {
+	const code = `
+		@property --brand {
+			syntax: '<color>';
+			inherits: true;
+			initial-value: #000;
+		}
+		a { color: var(--brand); }
+		b { color: var(--brand); }
+	`
+	const { warnings, errored } = await lint(code, 1)
+	// Same var() expression used twice → still 1 unique color
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+// ---------------------------------------------------------------------------
+// ignore secondary option
+// ---------------------------------------------------------------------------
+
+test('should not count ignored named colors', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: red; background-color: blue; }`,
+		1,
+		{ ignore: ['red'] },
+	)
+	// Only blue is counted → within limit
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not count ignored hex colors', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: #fff; background-color: #000; }`,
+		1,
+		{ ignore: ['#fff'] },
+	)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should support RegExp patterns in ignore', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: red; background-color: blue; border-color: green; }`,
+		1,
+		{ ignore: [/^(red|blue)$/] },
+	)
+	// Only green is not ignored → 1 unique color
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should support ignoring transparent', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: red; background-color: transparent; }`,
+		1,
+		{ ignore: ['transparent'] },
+	)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should support ignoring currentColor', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: red; border-color: currentColor; }`,
+		1,
+		{ ignore: ['currentColor'] },
+	)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should support ignoring color functions via RegExp', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: red; background: linear-gradient(oklch(0.5 0.2 120), oklch(0.8 0.1 60)); }`,
+		1,
+		{ ignore: [/^oklch\(/] },
+	)
+	// oklch() expressions are ignored → only red counts
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+// ---------------------------------------------------------------------------
+// Custom properties as color declarations
+// ---------------------------------------------------------------------------
+
+test('should detect colors declared in custom properties', async () => {
+	const { warnings, errored } = await lint(
+		`a { --text-color: red; --bg-color: blue; }`,
+		1,
+	)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+// ---------------------------------------------------------------------------
+// Multiple rules / selectors
+// ---------------------------------------------------------------------------
+
+test('should count unique colors across the entire stylesheet', async () => {
+	const { warnings, errored } = await lint(
+		`a { color: red; } b { color: blue; } c { color: green; }`,
+		2,
+	)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 3 unique colors')
+})
+
+test('should count each same color expression only once across declarations', async () => {
+	const { warnings, errored } = await lint(
+		`
+			a { color: oklch(0.5 0.2 120); }
+			b { background-color: oklch(0.5 0.2 120); }
+			c { border-color: oklch(0.5 0.2 120); }
+		`,
+		1,
+	)
+	// All three declarations use the same color string → 1 unique color
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})

--- a/src/rules/max-unique-colors/index.test.ts
+++ b/src/rules/max-unique-colors/index.test.ts
@@ -358,6 +358,63 @@ test('should count named color from nested var() fallback', async () => {
 // var() — with @property { syntax: '<color>' }
 // ---------------------------------------------------------------------------
 
+test('should count the @property initial-value as a unique color', async () => {
+	const code = `
+		@property --brand-color {
+			syntax: '<color>';
+			inherits: false;
+			initial-value: red;
+		}
+	`
+	// initial-value "red" counts even without any var() usage
+	const { warnings, errored } = await lint(code, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should count initial-value AND usages together', async () => {
+	const code = `
+		@property --brand-color {
+			syntax: '<color>';
+			inherits: false;
+			initial-value: red;
+		}
+		a { color: blue; }
+	`
+	// "red" (initial-value) + "blue" (declaration) = 2 unique colors
+	const { warnings, errored } = await lint(code, 1)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
+test('should not count initial-value for non-color @property', async () => {
+	const code = `
+		@property --size {
+			syntax: '<length>';
+			inherits: false;
+			initial-value: 0px;
+		}
+	`
+	const { warnings, errored } = await lint(code, 1)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should count initial-value with hex color', async () => {
+	const code = `
+		@property --brand-color {
+			syntax: '<color>';
+			inherits: false;
+			initial-value: #ff0000;
+		}
+		a { color: blue; }
+	`
+	// "#ff0000" + "blue" = 2 unique colors
+	const { warnings, errored } = await lint(code, 1)
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique colors')
+})
+
 test('should count var() referencing a @property <color> custom property', async () => {
 	const code = `
 		@property --brand-color {
@@ -367,7 +424,8 @@ test('should count var() referencing a @property <color> custom property', async
 		}
 		a { color: var(--brand-color); }
 	`
-	const { warnings, errored } = await lint(code, 1)
+	// "red" (initial-value) + "var(--brand-color)" = 2 unique colors
+	const { warnings, errored } = await lint(code, 2)
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
@@ -387,9 +445,10 @@ test('should count var() as a unique color when it is a @property <color>', asyn
 		a { color: var(--brand-color); }
 		b { color: var(--accent-color); }
 	`
+	// "red" + "blue" (initial-values) + "var(--brand-color)" + "var(--accent-color)" = 4 unique colors
 	const { warnings, errored } = await lint(code, 1)
 	expect(errored).toBe(true)
-	expect(warnings[0].text).toContain('Found 2 unique colors')
+	expect(warnings[0].text).toContain('Found 4 unique colors')
 })
 
 test('should count the var() expression AND fallback colors separately', async () => {
@@ -402,9 +461,10 @@ test('should count the var() expression AND fallback colors separately', async (
 		}
 		a { color: var(--brand-color, red); }
 	`
+	// "blue" (initial-value) + "var(--brand-color, red)" + "red" (fallback) = 3 unique colors
 	const { warnings, errored } = await lint(code, 1)
 	expect(errored).toBe(true)
-	expect(warnings[0].text).toContain('Found 2 unique colors')
+	expect(warnings[0].text).toContain('Found 3 unique colors')
 })
 
 test('should not count var() of a @property that does not have syntax <color>', async () => {
@@ -431,8 +491,8 @@ test('should handle @property with single-quoted syntax value', async () => {
 		a { color: var(--brand); }
 		b { color: var(--brand); }
 	`
-	const { warnings, errored } = await lint(code, 1)
-	// Same var() expression used twice → still 1 unique color
+	// "#000" (initial-value) + "var(--brand)" (used twice but same string → 1) = 2 unique colors
+	const { warnings, errored } = await lint(code, 2)
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })

--- a/src/rules/max-unique-colors/index.test.ts
+++ b/src/rules/max-unique-colors/index.test.ts
@@ -8,7 +8,8 @@ async function lint(code: string, primaryOption: unknown, secondaryOptions?: unk
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: secondaryOptions !== undefined ? [primaryOption, secondaryOptions] : primaryOption,
+			[rule_name]:
+				secondaryOptions !== undefined ? [primaryOption, secondaryOptions] : primaryOption,
 		},
 	}
 
@@ -68,10 +69,7 @@ test('should not error when the same named color is reused', async () => {
 })
 
 test('should not error when the same hex color is reused', async () => {
-	const { warnings, errored } = await lint(
-		`a { color: #fff; } b { background-color: #fff; }`,
-		1,
-	)
+	const { warnings, errored } = await lint(`a { color: #fff; } b { background-color: #fff; }`, 1)
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
@@ -124,10 +122,7 @@ test('should recognise transparent as a color', async () => {
 })
 
 test('should recognise currentColor as a color', async () => {
-	const { warnings, errored } = await lint(
-		`a { border-color: currentColor; color: red; }`,
-		1,
-	)
+	const { warnings, errored } = await lint(`a { border-color: currentColor; color: red; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toContain('Found 2 unique colors')
 })
@@ -239,21 +234,17 @@ test('should recognise color() as a color', async () => {
 })
 
 test('should recognise color-mix() as a color', async () => {
-	const { warnings, errored } = await lint(
-		`a { color: color-mix(in srgb, #fff 50%, #000); }`,
-		1,
-	)
-	// color-mix() itself is 1 unique color; #fff and #000 inside it are also counted
-	// → 3 unique colors total
-	expect(errored).toBe(true)
-	expect(warnings[0].text).toContain('Found 3 unique colors')
+	const { warnings, errored } = await lint(`a { color: color-mix(in srgb, #fff 50%, #000); }`, 1)
+	// color-mix() counts as 1 unique color; inner #fff and #000 are NOT counted separately
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
 })
 
 test('should recognise light-dark() as a color', async () => {
 	const { warnings, errored } = await lint(`a { color: light-dark(white, black); }`, 1)
-	// light-dark() itself is counted, plus white and black inside → 3 unique colors
-	expect(errored).toBe(true)
-	expect(warnings[0].text).toContain('Found 3 unique colors')
+	// light-dark() counts as 1 unique color; white and black inside are NOT counted separately
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
 })
 
 // ---------------------------------------------------------------------------
@@ -273,10 +264,7 @@ test('should detect colors in border shorthand', async () => {
 })
 
 test('should detect colors in box-shadow', async () => {
-	const { warnings, errored } = await lint(
-		`a { box-shadow: 0 0 10px red, 0 0 20px blue; }`,
-		1,
-	)
+	const { warnings, errored } = await lint(`a { box-shadow: 0 0 10px red, 0 0 20px blue; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toContain('Found 2 unique colors')
 })
@@ -288,10 +276,7 @@ test('should detect colors in text-shadow', async () => {
 })
 
 test('should detect named colors inside linear-gradient()', async () => {
-	const { warnings, errored } = await lint(
-		`a { background-image: linear-gradient(red, blue); }`,
-		1,
-	)
+	const { warnings, errored } = await lint(`a { background-image: linear-gradient(red, blue); }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toContain('Found 2 unique colors')
 })
@@ -319,10 +304,7 @@ test('should detect colors in SVG stroke property', async () => {
 
 test('should not count non-color properties', async () => {
 	// font-size, margin, padding etc. should not contribute to color count
-	const { warnings, errored } = await lint(
-		`a { font-size: 16px; margin: 0; padding: 10px; }`,
-		1,
-	)
+	const { warnings, errored } = await lint(`a { font-size: 16px; margin: 0; padding: 10px; }`, 1)
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
@@ -460,22 +442,18 @@ test('should handle @property with single-quoted syntax value', async () => {
 // ---------------------------------------------------------------------------
 
 test('should not count ignored named colors', async () => {
-	const { warnings, errored } = await lint(
-		`a { color: red; background-color: blue; }`,
-		1,
-		{ ignore: ['red'] },
-	)
+	const { warnings, errored } = await lint(`a { color: red; background-color: blue; }`, 1, {
+		ignore: ['red'],
+	})
 	// Only blue is counted → within limit
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
 
 test('should not count ignored hex colors', async () => {
-	const { warnings, errored } = await lint(
-		`a { color: #fff; background-color: #000; }`,
-		1,
-		{ ignore: ['#fff'] },
-	)
+	const { warnings, errored } = await lint(`a { color: #fff; background-color: #000; }`, 1, {
+		ignore: ['#fff'],
+	})
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
@@ -492,21 +470,17 @@ test('should support RegExp patterns in ignore', async () => {
 })
 
 test('should support ignoring transparent', async () => {
-	const { warnings, errored } = await lint(
-		`a { color: red; background-color: transparent; }`,
-		1,
-		{ ignore: ['transparent'] },
-	)
+	const { warnings, errored } = await lint(`a { color: red; background-color: transparent; }`, 1, {
+		ignore: ['transparent'],
+	})
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
 
 test('should support ignoring currentColor', async () => {
-	const { warnings, errored } = await lint(
-		`a { color: red; border-color: currentColor; }`,
-		1,
-		{ ignore: ['currentColor'] },
-	)
+	const { warnings, errored } = await lint(`a { color: red; border-color: currentColor; }`, 1, {
+		ignore: ['currentColor'],
+	})
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
@@ -527,10 +501,7 @@ test('should support ignoring color functions via RegExp', async () => {
 // ---------------------------------------------------------------------------
 
 test('should detect colors declared in custom properties', async () => {
-	const { warnings, errored } = await lint(
-		`a { --text-color: red; --bg-color: blue; }`,
-		1,
-	)
+	const { warnings, errored } = await lint(`a { --text-color: red; --bg-color: blue; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toContain('Found 2 unique colors')
 })

--- a/src/rules/max-unique-colors/index.ts
+++ b/src/rules/max-unique-colors/index.ts
@@ -1,0 +1,324 @@
+import stylelint from 'stylelint'
+import type { Root } from 'postcss'
+import { parse_value } from '@projectwallace/css-parser/parse-value'
+import { walk } from '@projectwallace/css-parser/walker'
+import { FUNCTION, HASH, IDENTIFIER } from '@projectwallace/css-parser/nodes'
+import { isAllowed } from '../../utils/allow-list.js'
+
+const { createPlugin, utils } = stylelint
+
+const rule_name = 'projectwallace/max-unique-colors'
+
+const messages = utils.ruleMessages(rule_name, {
+	rejected: (actual: number, expected: number, colors: string[]) =>
+		`Found ${actual} unique colors (${colors.join(', ')}) which exceeds the maximum of ${expected}`,
+})
+
+const meta = {
+	url: 'https://github.com/projectwallace/stylelint-plugin/blob/main/src/rules/max-unique-colors/README.md',
+}
+
+/**
+ * CSS color function names. These are functions that produce a color value
+ * and are counted as a single unique color (the whole expression).
+ */
+const COLOR_FUNCTIONS = new Set([
+	'rgb',
+	'rgba',
+	'hsl',
+	'hsla',
+	'hwb',
+	'lab',
+	'lch',
+	'oklab',
+	'oklch',
+	'color',
+	'color-mix',
+	'light-dark',
+	'device-cmyk',
+])
+
+/**
+ * All CSS named colors (lowercase), including special keywords
+ * transparent and currentcolor.
+ * Source: https://www.w3.org/TR/css-color-4/#named-colors
+ */
+const NAMED_COLORS = new Set([
+	'aliceblue',
+	'antiquewhite',
+	'aqua',
+	'aquamarine',
+	'azure',
+	'beige',
+	'bisque',
+	'black',
+	'blanchedalmond',
+	'blue',
+	'blueviolet',
+	'brown',
+	'burlywood',
+	'cadetblue',
+	'chartreuse',
+	'chocolate',
+	'coral',
+	'cornflowerblue',
+	'cornsilk',
+	'crimson',
+	'cyan',
+	'darkblue',
+	'darkcyan',
+	'darkgoldenrod',
+	'darkgray',
+	'darkgreen',
+	'darkgrey',
+	'darkkhaki',
+	'darkmagenta',
+	'darkolivegreen',
+	'darkorange',
+	'darkorchid',
+	'darkred',
+	'darksalmon',
+	'darkseagreen',
+	'darkslateblue',
+	'darkslategray',
+	'darkslategrey',
+	'darkturquoise',
+	'darkviolet',
+	'deeppink',
+	'deepskyblue',
+	'dimgray',
+	'dimgrey',
+	'dodgerblue',
+	'firebrick',
+	'floralwhite',
+	'forestgreen',
+	'fuchsia',
+	'gainsboro',
+	'ghostwhite',
+	'gold',
+	'goldenrod',
+	'gray',
+	'green',
+	'greenyellow',
+	'grey',
+	'honeydew',
+	'hotpink',
+	'indianred',
+	'indigo',
+	'ivory',
+	'khaki',
+	'lavender',
+	'lavenderblush',
+	'lawngreen',
+	'lemonchiffon',
+	'lightblue',
+	'lightcoral',
+	'lightcyan',
+	'lightgoldenrodyellow',
+	'lightgray',
+	'lightgreen',
+	'lightgrey',
+	'lightpink',
+	'lightsalmon',
+	'lightseagreen',
+	'lightskyblue',
+	'lightslategray',
+	'lightslategrey',
+	'lightsteelblue',
+	'lightyellow',
+	'lime',
+	'limegreen',
+	'linen',
+	'magenta',
+	'maroon',
+	'mediumaquamarine',
+	'mediumblue',
+	'mediumorchid',
+	'mediumpurple',
+	'mediumseagreen',
+	'mediumslateblue',
+	'mediumspringgreen',
+	'mediumturquoise',
+	'mediumvioletred',
+	'midnightblue',
+	'mintcream',
+	'mistyrose',
+	'moccasin',
+	'navajowhite',
+	'navy',
+	'oldlace',
+	'olive',
+	'olivedrab',
+	'orange',
+	'orangered',
+	'orchid',
+	'palegoldenrod',
+	'palegreen',
+	'paleturquoise',
+	'palevioletred',
+	'papayawhip',
+	'peachpuff',
+	'peru',
+	'pink',
+	'plum',
+	'powderblue',
+	'purple',
+	'rebeccapurple',
+	'red',
+	'rosybrown',
+	'royalblue',
+	'saddlebrown',
+	'salmon',
+	'sandybrown',
+	'seagreen',
+	'seashell',
+	'sienna',
+	'silver',
+	'skyblue',
+	'slateblue',
+	'slategray',
+	'slategrey',
+	'snow',
+	'springgreen',
+	'steelblue',
+	'tan',
+	'teal',
+	'thistle',
+	'tomato',
+	'turquoise',
+	'violet',
+	'wheat',
+	'white',
+	'whitesmoke',
+	'yellow',
+	'yellowgreen',
+	// Special color keywords
+	'transparent',
+	'currentcolor',
+])
+
+/**
+ * CSS properties whose declaration values may contain color values.
+ * This is used to filter walkDecls to only visit relevant declarations.
+ */
+const COLOR_PROPERTIES =
+	/^(?:color|background(?:-color|-image)?|border(?:-color|-top(?:-color)?|-right(?:-color)?|-bottom(?:-color)?|-left(?:-color)?|-block(?:-color|-start(?:-color)?|-end(?:-color)?)?|-inline(?:-color|-start(?:-color)?|-end(?:-color)?)?)?|outline(?:-color)?|text-decoration(?:-color)?|column-rule(?:-color)?|caret-color|fill|stroke|stop-color|flood-color|lighting-color|text-emphasis(?:-color)?|scrollbar-color|accent-color|box-shadow|text-shadow|filter|-webkit-text-fill-color|-webkit-tap-highlight-color|-webkit-text-stroke(?:-color)?|--.+)$/i
+
+/**
+ * Valid CSS hex color lengths after the '#': 3 (#RGB), 4 (#RGBA),
+ * 6 (#RRGGBB), or 8 (#RRGGBBAA) hex digits.
+ */
+const HEX_COLOR_RE = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+
+interface SecondaryOptions {
+	ignore?: Array<string | RegExp>
+}
+
+const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions) => {
+	return (root: Root, result: stylelint.PostcssResult) => {
+		const validOptions = utils.validateOptions(
+			result,
+			rule_name,
+			{
+				actual: primaryOption,
+				possible: [Number as unknown as (v: unknown) => boolean],
+			},
+			{
+				actual: secondaryOptions,
+				possible: {
+					ignore: [
+						String as unknown as (v: unknown) => boolean,
+						(v: unknown) => v instanceof RegExp,
+					],
+				},
+				optional: true,
+			},
+		)
+
+		if (!validOptions || !Number.isInteger(primaryOption) || primaryOption <= 0) {
+			return
+		}
+
+		const ignore = secondaryOptions?.ignore ?? []
+
+		/**
+		 * Collect custom properties defined as <color> via @property { syntax: '<color>' }.
+		 * These are recognised as color values when referenced via var().
+		 */
+		const color_custom_properties = new Set<string>()
+
+		root.walkAtRules('property', (atRule) => {
+			const prop_name = atRule.params.trim()
+			if (!prop_name.startsWith('--')) return
+
+			atRule.walkDecls('syntax', (decl) => {
+				// syntax values may be quoted: '"<color>"' or "'<color>'"
+				const syntax = decl.value.trim().replace(/^['"]|['"]$/g, '')
+				if (syntax === '<color>') {
+					color_custom_properties.add(prop_name)
+				}
+			})
+		})
+
+		const unique_colors = new Set<string>()
+
+		root.walkDecls(COLOR_PROPERTIES, (declaration) => {
+			const parsed = parse_value(declaration.value)
+
+			walk(parsed, (node) => {
+				let color: string | undefined
+
+				if (node.type === HASH) {
+					// Hex colors: #RGB, #RGBA, #RRGGBB, #RRGGBBAA
+					if (HEX_COLOR_RE.test(node.text)) {
+						color = node.text
+					}
+				} else if (node.type === IDENTIFIER) {
+					// Named colors and special keywords (currentcolor, transparent).
+					// Lookup is case-insensitive; the original casing is preserved for uniqueness.
+					if (NAMED_COLORS.has(node.text.toLowerCase())) {
+						color = node.text
+					}
+				} else if (node.type === FUNCTION) {
+					const fn_name = node.name?.toLowerCase()
+
+					if (fn_name !== undefined && COLOR_FUNCTIONS.has(fn_name)) {
+						// Color functions such as rgb(), hsl(), oklch(), color-mix(), etc.
+						color = node.text
+					} else if (fn_name === 'var') {
+						// var() referencing a custom property declared as <color> via @property
+						const first = node.first_child
+						if (
+							first !== null &&
+							first.type === IDENTIFIER &&
+							color_custom_properties.has(first.text)
+						) {
+							color = node.text
+						}
+					}
+				}
+
+				if (color !== undefined && !isAllowed(color, ignore)) {
+					unique_colors.add(color)
+				}
+			})
+		})
+
+		const actual = unique_colors.size
+
+		if (actual > primaryOption) {
+			utils.report({
+				message: messages.rejected(actual, primaryOption, [...unique_colors]),
+				node: root,
+				result,
+				ruleName: rule_name,
+			})
+		}
+	}
+}
+
+ruleFunction.ruleName = rule_name
+ruleFunction.messages = messages
+ruleFunction.meta = meta
+
+export default createPlugin(rule_name, ruleFunction)

--- a/src/rules/max-unique-colors/index.ts
+++ b/src/rules/max-unique-colors/index.ts
@@ -4,7 +4,7 @@ import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { walk, SKIP } from '@projectwallace/css-parser'
 import { FUNCTION, HASH, IDENTIFIER } from '@projectwallace/css-parser/nodes'
 import { namedColors, colorFunctions, colorKeywords } from '@projectwallace/css-analyzer/values'
-import { isAllowed } from '../../utils/allow-list.js'
+import { isAllowed as isIgnored } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -70,6 +70,71 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		 * var() references to these are recognised as color values.
 		 */
 		const color_custom_properties = new Set<string>()
+		const unique_colors = new Set<string>()
+
+		/**
+		 * Walk a parsed CSS value and add any detected color tokens to unique_colors.
+		 * When `resolve_var` is true, var() references to known @property <color>
+		 * custom properties are also counted. CSS does not allow var() in
+		 * @property initial-value, so pass false when scanning initial-value.
+		 */
+		function collect_colors(parsed: ReturnType<typeof parse_value>, resolve_var: boolean): void {
+			walk(parsed, (node) => {
+				if (node.type === HASH) {
+					// The parser already guarantees HASH nodes are valid hex colors.
+					if (!isIgnored(node.text, ignore)) {
+						unique_colors.add(node.text)
+					}
+				} else if (node.type === IDENTIFIER) {
+					// namedColors and colorKeywords both perform case-insensitive matching.
+					if (namedColors.has(node.text) || colorKeywords.has(node.text)) {
+						if (!isIgnored(node.text, ignore)) {
+							unique_colors.add(node.text)
+						}
+					}
+				} else if (node.type === FUNCTION) {
+					const fn_name = node.name
+					if (fn_name === undefined) return
+
+					// colorFunctions.has() is case-insensitive.
+					if (colorFunctions.has(fn_name)) {
+						// Numeric-channel color functions (rgb, hsl, oklch, …).
+						// SKIP children — they are numbers, not color tokens.
+						if (!isIgnored(node.text, ignore)) {
+							unique_colors.add(node.text)
+						}
+						return SKIP
+					}
+
+					const fn_name_lower = fn_name.toLowerCase()
+
+					if (COLOR_COMPOSING_FUNCTIONS.has(fn_name_lower)) {
+						// Composing color functions (color-mix, light-dark, device-cmyk) take
+						// color values as arguments. SKIP children so they are not double-counted.
+						if (!isIgnored(node.text, ignore)) {
+							unique_colors.add(node.text)
+						}
+						return SKIP
+					}
+
+					if (resolve_var && fn_name_lower === 'var') {
+						// var() referencing a custom property declared as <color> via @property.
+						// Count the whole var() expression, but do NOT skip children so that
+						// any fallback color values are still evaluated.
+						const first = node.first_child
+						if (
+							first !== null &&
+							first.type === IDENTIFIER &&
+							color_custom_properties.has(first.text)
+						) {
+							if (!isIgnored(node.text, ignore)) {
+								unique_colors.add(node.text)
+							}
+						}
+					}
+				}
+			})
+		}
 
 		root.walkAtRules('property', (atRule) => {
 			const prop_name = atRule.params.trim()
@@ -82,71 +147,16 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 					color_custom_properties.add(prop_name)
 				}
 			})
+
+			if (!color_custom_properties.has(prop_name)) return
+
+			atRule.walkDecls('initial-value', (decl) => {
+				collect_colors(parse_value(decl.value), false)
+			})
 		})
 
-		const unique_colors = new Set<string>()
-
 		root.walkDecls(COLOR_PROPERTIES, (declaration) => {
-			const parsed = parse_value(declaration.value)
-
-			walk(parsed, (node) => {
-				if (node.type === HASH) {
-					// The parser already guarantees HASH nodes are valid hex colors.
-					if (!isAllowed(node.text, ignore)) {
-						unique_colors.add(node.text)
-					}
-				} else if (node.type === IDENTIFIER) {
-					// namedColors and colorKeywords both perform case-insensitive matching.
-					if (namedColors.has(node.text) || colorKeywords.has(node.text)) {
-						if (!isAllowed(node.text, ignore)) {
-							unique_colors.add(node.text)
-						}
-					}
-				} else if (node.type === FUNCTION) {
-					const fn_name = node.name
-					if (fn_name === undefined) return
-
-					// node.name is compared case-insensitively by colorFunctions.has().
-					if (colorFunctions.has(fn_name)) {
-						// Numeric-channel color functions (rgb, hsl, oklch, …).
-						// Return SKIP so we don't descend into their children — while those
-						// children are numbers and wouldn't be mistaken for colors, being
-						// consistent avoids surprises if the function appears in a complex value.
-						if (!isAllowed(node.text, ignore)) {
-							unique_colors.add(node.text)
-						}
-						return SKIP
-					}
-
-					const fn_name_lower = fn_name.toLowerCase()
-
-					if (COLOR_COMPOSING_FUNCTIONS.has(fn_name_lower)) {
-						// Composing color functions (color-mix, light-dark, device-cmyk) take
-						// color values as arguments.  Count the whole expression as one unique
-						// color and skip children so the inner colors are not double-counted.
-						if (!isAllowed(node.text, ignore)) {
-							unique_colors.add(node.text)
-						}
-						return SKIP
-					}
-
-					if (fn_name_lower === 'var') {
-						// var() referencing a custom property declared as <color> via @property.
-						// Count the whole var() expression, but do NOT skip children so that
-						// any fallback color values are still evaluated.
-						const first = node.first_child
-						if (
-							first !== null &&
-							first.type === IDENTIFIER &&
-							color_custom_properties.has(first.text)
-						) {
-							if (!isAllowed(node.text, ignore)) {
-								unique_colors.add(node.text)
-							}
-						}
-					}
-				}
-			})
+			collect_colors(parse_value(declaration.value), true)
 		})
 
 		const actual = unique_colors.size

--- a/src/rules/max-unique-colors/index.ts
+++ b/src/rules/max-unique-colors/index.ts
@@ -1,8 +1,9 @@
 import stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
-import { walk } from '@projectwallace/css-parser/walker'
+import { walk, SKIP } from '@projectwallace/css-parser'
 import { FUNCTION, HASH, IDENTIFIER } from '@projectwallace/css-parser/nodes'
+import { namedColors, colorFunctions, colorKeywords } from '@projectwallace/css-analyzer/values'
 import { isAllowed } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
@@ -19,196 +20,19 @@ const meta = {
 }
 
 /**
- * CSS color function names. These are functions that produce a color value
- * and are counted as a single unique color (the whole expression).
+ * Color functions not included in css-analyzer's colorFunctions because they
+ * accept color values as arguments rather than numeric channel components.
+ * We must return SKIP after counting them so their inner color tokens are not
+ * also counted as separate unique colors.
  */
-const COLOR_FUNCTIONS = new Set([
-	'rgb',
-	'rgba',
-	'hsl',
-	'hsla',
-	'hwb',
-	'lab',
-	'lch',
-	'oklab',
-	'oklch',
-	'color',
-	'color-mix',
-	'light-dark',
-	'device-cmyk',
-])
-
-/**
- * All CSS named colors (lowercase), including special keywords
- * transparent and currentcolor.
- * Source: https://www.w3.org/TR/css-color-4/#named-colors
- */
-const NAMED_COLORS = new Set([
-	'aliceblue',
-	'antiquewhite',
-	'aqua',
-	'aquamarine',
-	'azure',
-	'beige',
-	'bisque',
-	'black',
-	'blanchedalmond',
-	'blue',
-	'blueviolet',
-	'brown',
-	'burlywood',
-	'cadetblue',
-	'chartreuse',
-	'chocolate',
-	'coral',
-	'cornflowerblue',
-	'cornsilk',
-	'crimson',
-	'cyan',
-	'darkblue',
-	'darkcyan',
-	'darkgoldenrod',
-	'darkgray',
-	'darkgreen',
-	'darkgrey',
-	'darkkhaki',
-	'darkmagenta',
-	'darkolivegreen',
-	'darkorange',
-	'darkorchid',
-	'darkred',
-	'darksalmon',
-	'darkseagreen',
-	'darkslateblue',
-	'darkslategray',
-	'darkslategrey',
-	'darkturquoise',
-	'darkviolet',
-	'deeppink',
-	'deepskyblue',
-	'dimgray',
-	'dimgrey',
-	'dodgerblue',
-	'firebrick',
-	'floralwhite',
-	'forestgreen',
-	'fuchsia',
-	'gainsboro',
-	'ghostwhite',
-	'gold',
-	'goldenrod',
-	'gray',
-	'green',
-	'greenyellow',
-	'grey',
-	'honeydew',
-	'hotpink',
-	'indianred',
-	'indigo',
-	'ivory',
-	'khaki',
-	'lavender',
-	'lavenderblush',
-	'lawngreen',
-	'lemonchiffon',
-	'lightblue',
-	'lightcoral',
-	'lightcyan',
-	'lightgoldenrodyellow',
-	'lightgray',
-	'lightgreen',
-	'lightgrey',
-	'lightpink',
-	'lightsalmon',
-	'lightseagreen',
-	'lightskyblue',
-	'lightslategray',
-	'lightslategrey',
-	'lightsteelblue',
-	'lightyellow',
-	'lime',
-	'limegreen',
-	'linen',
-	'magenta',
-	'maroon',
-	'mediumaquamarine',
-	'mediumblue',
-	'mediumorchid',
-	'mediumpurple',
-	'mediumseagreen',
-	'mediumslateblue',
-	'mediumspringgreen',
-	'mediumturquoise',
-	'mediumvioletred',
-	'midnightblue',
-	'mintcream',
-	'mistyrose',
-	'moccasin',
-	'navajowhite',
-	'navy',
-	'oldlace',
-	'olive',
-	'olivedrab',
-	'orange',
-	'orangered',
-	'orchid',
-	'palegoldenrod',
-	'palegreen',
-	'paleturquoise',
-	'palevioletred',
-	'papayawhip',
-	'peachpuff',
-	'peru',
-	'pink',
-	'plum',
-	'powderblue',
-	'purple',
-	'rebeccapurple',
-	'red',
-	'rosybrown',
-	'royalblue',
-	'saddlebrown',
-	'salmon',
-	'sandybrown',
-	'seagreen',
-	'seashell',
-	'sienna',
-	'silver',
-	'skyblue',
-	'slateblue',
-	'slategray',
-	'slategrey',
-	'snow',
-	'springgreen',
-	'steelblue',
-	'tan',
-	'teal',
-	'thistle',
-	'tomato',
-	'turquoise',
-	'violet',
-	'wheat',
-	'white',
-	'whitesmoke',
-	'yellow',
-	'yellowgreen',
-	// Special color keywords
-	'transparent',
-	'currentcolor',
-])
+const COLOR_COMPOSING_FUNCTIONS = new Set(['color-mix', 'light-dark', 'device-cmyk'])
 
 /**
  * CSS properties whose declaration values may contain color values.
- * This is used to filter walkDecls to only visit relevant declarations.
+ * Used to filter walkDecls so only relevant declarations are visited.
  */
 const COLOR_PROPERTIES =
 	/^(?:color|background(?:-color|-image)?|border(?:-color|-top(?:-color)?|-right(?:-color)?|-bottom(?:-color)?|-left(?:-color)?|-block(?:-color|-start(?:-color)?|-end(?:-color)?)?|-inline(?:-color|-start(?:-color)?|-end(?:-color)?)?)?|outline(?:-color)?|text-decoration(?:-color)?|column-rule(?:-color)?|caret-color|fill|stroke|stop-color|flood-color|lighting-color|text-emphasis(?:-color)?|scrollbar-color|accent-color|box-shadow|text-shadow|filter|-webkit-text-fill-color|-webkit-tap-highlight-color|-webkit-text-stroke(?:-color)?|--.+)$/i
-
-/**
- * Valid CSS hex color lengths after the '#': 3 (#RGB), 4 (#RGBA),
- * 6 (#RRGGBB), or 8 (#RRGGBBAA) hex digits.
- */
-const HEX_COLOR_RE = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i
 
 interface SecondaryOptions {
 	ignore?: Array<string | RegExp>
@@ -242,8 +66,8 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const ignore = secondaryOptions?.ignore ?? []
 
 		/**
-		 * Collect custom properties defined as <color> via @property { syntax: '<color>' }.
-		 * These are recognised as color values when referenced via var().
+		 * Collect custom properties declared as @property { syntax: '<color>' }.
+		 * var() references to these are recognised as color values.
 		 */
 		const color_custom_properties = new Set<string>()
 
@@ -266,40 +90,61 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			const parsed = parse_value(declaration.value)
 
 			walk(parsed, (node) => {
-				let color: string | undefined
-
 				if (node.type === HASH) {
-					// Hex colors: #RGB, #RGBA, #RRGGBB, #RRGGBBAA
-					if (HEX_COLOR_RE.test(node.text)) {
-						color = node.text
+					// The parser already guarantees HASH nodes are valid hex colors.
+					if (!isAllowed(node.text, ignore)) {
+						unique_colors.add(node.text)
 					}
 				} else if (node.type === IDENTIFIER) {
-					// Named colors and special keywords (currentcolor, transparent).
-					// Lookup is case-insensitive; the original casing is preserved for uniqueness.
-					if (NAMED_COLORS.has(node.text.toLowerCase())) {
-						color = node.text
+					// namedColors and colorKeywords both perform case-insensitive matching.
+					if (namedColors.has(node.text) || colorKeywords.has(node.text)) {
+						if (!isAllowed(node.text, ignore)) {
+							unique_colors.add(node.text)
+						}
 					}
 				} else if (node.type === FUNCTION) {
-					const fn_name = node.name?.toLowerCase()
+					const fn_name = node.name
+					if (fn_name === undefined) return
 
-					if (fn_name !== undefined && COLOR_FUNCTIONS.has(fn_name)) {
-						// Color functions such as rgb(), hsl(), oklch(), color-mix(), etc.
-						color = node.text
-					} else if (fn_name === 'var') {
-						// var() referencing a custom property declared as <color> via @property
+					// node.name is compared case-insensitively by colorFunctions.has().
+					if (colorFunctions.has(fn_name)) {
+						// Numeric-channel color functions (rgb, hsl, oklch, …).
+						// Return SKIP so we don't descend into their children — while those
+						// children are numbers and wouldn't be mistaken for colors, being
+						// consistent avoids surprises if the function appears in a complex value.
+						if (!isAllowed(node.text, ignore)) {
+							unique_colors.add(node.text)
+						}
+						return SKIP
+					}
+
+					const fn_name_lower = fn_name.toLowerCase()
+
+					if (COLOR_COMPOSING_FUNCTIONS.has(fn_name_lower)) {
+						// Composing color functions (color-mix, light-dark, device-cmyk) take
+						// color values as arguments.  Count the whole expression as one unique
+						// color and skip children so the inner colors are not double-counted.
+						if (!isAllowed(node.text, ignore)) {
+							unique_colors.add(node.text)
+						}
+						return SKIP
+					}
+
+					if (fn_name_lower === 'var') {
+						// var() referencing a custom property declared as <color> via @property.
+						// Count the whole var() expression, but do NOT skip children so that
+						// any fallback color values are still evaluated.
 						const first = node.first_child
 						if (
 							first !== null &&
 							first.type === IDENTIFIER &&
 							color_custom_properties.has(first.text)
 						) {
-							color = node.text
+							if (!isAllowed(node.text, ignore)) {
+								unique_colors.add(node.text)
+							}
 						}
 					}
-				}
-
-				if (color !== undefined && !isAllowed(color, ignore)) {
-					unique_colors.add(color)
 				}
 			})
 		})


### PR DESCRIPTION
## Summary

This PR introduces a new stylelint rule `projectwallace/max-unique-colors` that limits the number of unique color values used across a stylesheet. This helps enforce consistent design systems by preventing excessive color proliferation.

## Key Changes

- **New rule implementation** (`src/rules/max-unique-colors/index.ts`):
  - Detects and counts unique colors across the entire stylesheet
  - Supports named colors, hex colors, and all CSS color functions (rgb, hsl, hwb, lab, lch, oklab, oklch, color, color-mix, light-dark, etc.)
  - Recognizes `var()` references to custom properties declared with `@property { syntax: '<color>' }`
  - Handles color values in shorthand properties (background, border) and shadow properties (box-shadow, text-shadow)
  - Includes gradient color detection (linear-gradient, radial-gradient, etc.)
  - Supports an `ignore` option to exclude specific colors or patterns from the count

- **Comprehensive test suite** (`src/rules/max-unique-colors/index.test.ts`):
  - 534 lines of tests covering option validation, basic cases, violations, and edge cases
  - Tests for all color formats and functions
  - Tests for custom properties and @property declarations
  - Tests for the ignore option with both string and RegExp patterns
  - Tests for color detection across multiple selectors and rules

- **Documentation** (`src/rules/max-unique-colors/README.md`):
  - Clear explanation of what the rule does
  - Examples of violations and valid patterns
  - Documentation of the `ignore` option
  - Detailed explanation of `var()` and `@property` behavior

- **Plugin registration** (`src/index.ts`):
  - Registered the new rule in the main plugin export

## Implementation Details

- Colors are compared by their exact string representation (e.g., `#f00` and `#ff0000` are treated as distinct)
- The rule reports violations at the stylesheet root level
- Color-composing functions (color-mix, light-dark) are counted as single colors without descending into their arguments
- Fallback values in `var()` expressions are evaluated separately from the var() itself
- The rule integrates with the existing `@projectwallace/css-parser` and `@projectwallace/css-analyzer` libraries for robust color detection

https://claude.ai/code/session_01MGzFeD7AqFkinhqFaEpKeQ