### PR TITLE
breaking: consolidate `ignore` options are called and work the same

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ npm run lint
 4. Consider adding the rule to one or more of the configuration presets in `src/configs/`
 5. Use PostCSS API's as much as possible. Only if goals cannot be achieved reach for `@projectwallace/css-parser`
 6. Only use `@projectwallace/css-parser` methods `parse_value()`, `parse_selector()`, or `parse_atrule_prelude()`. Other parsing methods SHOULD NOT be necessary.
+7. If the rule should allow users to exclude specific values, add a secondary `ignore` option (see [the `ignore` option pattern](#the-ignore-option-pattern) below).
 
 ## Rule README guidelines
 
@@ -27,7 +28,33 @@ Every rule's `README.md` must:
 - Show at least one example of a **violation** and one **passing** pattern
 - Document all available options
 
-Rules that disallow certain behaviour (e.g. `no-unused-x`, `no-undefined-x`) should implement a secondary `allowList` option. This option accepts an array of `string | RegExp` values and must be consistent across all rules that implement it. Use the shared `isAllowed(value, allowList)` utility from `src/utils/allow-list.ts` to evaluate it.
+## The `ignore` option pattern
+
+When a rule should let users exclude specific values from being checked, name the secondary option `ignore`. It accepts `Array<string | RegExp>`. Both exact string matches and regular expressions must be supported.
+
+**Naming:** always `ignore`, never `allowList`, `ignoreValues`, `ignoreProperties`, or any other variant.
+
+**Validation** — import `ignoreOptionValidators` from `src/utils/allow-list.ts` and pass it to `validateOptions`:
+
+```ts
+import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
+
+// inside validateOptions:
+{
+  actual: secondaryOptions,
+  possible: { ignore: ignoreOptionValidators },
+  optional: true,
+}
+```
+
+**Checking** — import `isAllowed` from the same utility and call it with the value and the option:
+
+```ts
+const ignore = secondaryOptions?.ignore ?? []
+if (!isAllowed(value, ignore)) {
+	/* count or report */
+}
+```
 
 ## Adding a new config
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The easiest way to get started is by extending one of the preset configs:
 
 ```json
 {
-  "extends": ["@projectwallace/stylelint-plugin/configs/recommended"]
+	"extends": ["@projectwallace/stylelint-plugin/configs/recommended"]
 }
 ```
 
@@ -34,45 +34,45 @@ Alternatively, add the plugin and configure rules individually in your stylelint
 
 ```json
 {
-  "plugins": ["@projectwallace/stylelint-plugin"],
-  "rules": {
-    "projectwallace/max-average-declarations-per-rule": 5,
-    "projectwallace/max-average-selector-complexity": 2,
-    "projectwallace/max-average-selectors-per-rule": 2,
-    "projectwallace/max-average-specificity": [0, 2.5, 1],
-    "projectwallace/max-comment-size": 2500,
-    "projectwallace/max-embedded-content-size": 10000,
-    "projectwallace/max-file-size": 200000,
-    "projectwallace/max-important-ratio": 1,
-    "projectwallace/max-declarations-per-rule": 15,
-    "projectwallace/max-lines-of-code": 200,
-    "projectwallace/max-selector-complexity": 5,
-    "projectwallace/max-selectors-per-rule": 10,
-    "projectwallace/max-unique-animation-functions": 4,
-    "projectwallace/max-unique-colors": 5,
-    "projectwallace/max-unique-durations": 8,
-    "projectwallace/max-unique-box-shadows": 3,
-    "projectwallace/max-unique-gradients": 5,
-    "projectwallace/max-unique-font-families": 4,
-    "projectwallace/max-unique-font-sizes": 16,
-    "projectwallace/max-unique-units": 5,
-    "projectwallace/min-declaration-uniqueness-ratio": 0.5,
-    "projectwallace/min-selector-uniqueness-ratio": 0.66,
-    "projectwallace/no-anonymous-layers": true,
-    "projectwallace/no-duplicate-data-urls": true,
-    "projectwallace/no-property-browserhacks": true,
-    "projectwallace/no-static-container-query": true,
-    "projectwallace/no-static-media-query": true,
-    "projectwallace/no-undeclared-container-names": true,
-    "projectwallace/no-unknown-custom-property": true,
-    "projectwallace/no-unreachable-media-conditions": true,
-    "projectwallace/no-unused-container-names": true,
-    "projectwallace/no-unused-custom-properties": true,
-    "projectwallace/no-unused-layers": true,
-    "projectwallace/no-invalid-z-index": true,
-    "projectwallace/no-property-shorthand": true,
-    "projectwallace/no-useless-custom-property-assignment": true
-  }
+	"plugins": ["@projectwallace/stylelint-plugin"],
+	"rules": {
+		"projectwallace/max-average-declarations-per-rule": 5,
+		"projectwallace/max-average-selector-complexity": 2,
+		"projectwallace/max-average-selectors-per-rule": 2,
+		"projectwallace/max-average-specificity": [0, 2.5, 1],
+		"projectwallace/max-comment-size": 2500,
+		"projectwallace/max-embedded-content-size": 10000,
+		"projectwallace/max-file-size": 200000,
+		"projectwallace/max-important-ratio": 1,
+		"projectwallace/max-declarations-per-rule": 15,
+		"projectwallace/max-lines-of-code": 200,
+		"projectwallace/max-selector-complexity": 5,
+		"projectwallace/max-selectors-per-rule": 10,
+		"projectwallace/max-unique-animation-functions": 4,
+		"projectwallace/max-unique-colors": 5,
+		"projectwallace/max-unique-durations": 8,
+		"projectwallace/max-unique-box-shadows": 3,
+		"projectwallace/max-unique-gradients": 5,
+		"projectwallace/max-unique-font-families": 4,
+		"projectwallace/max-unique-font-sizes": 16,
+		"projectwallace/max-unique-units": 5,
+		"projectwallace/min-declaration-uniqueness-ratio": 0.5,
+		"projectwallace/min-selector-uniqueness-ratio": 0.66,
+		"projectwallace/no-anonymous-layers": true,
+		"projectwallace/no-duplicate-data-urls": true,
+		"projectwallace/no-property-browserhacks": true,
+		"projectwallace/no-static-container-query": true,
+		"projectwallace/no-static-media-query": true,
+		"projectwallace/no-undeclared-container-names": true,
+		"projectwallace/no-unknown-custom-property": true,
+		"projectwallace/no-unreachable-media-conditions": true,
+		"projectwallace/no-unused-container-names": true,
+		"projectwallace/no-unused-custom-properties": true,
+		"projectwallace/no-unused-layers": true,
+		"projectwallace/no-invalid-z-index": true,
+		"projectwallace/no-property-shorthand": true,
+		"projectwallace/no-useless-custom-property-assignment": true
+	}
 }
 ```
 

--- a/src/rules/max-unique-animation-functions/index.ts
+++ b/src/rules/max-unique-animation-functions/index.ts
@@ -1,6 +1,6 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
-import { isAllowed } from '../../utils/allow-list.js'
+import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 import { analyzeAnimation } from '@projectwallace/css-analyzer/values'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { OPERATOR } from '@projectwallace/css-parser'
@@ -34,10 +34,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignore: [
-						String as unknown as (v: unknown) => boolean,
-						(v: unknown) => v instanceof RegExp,
-					],
+					ignore: ignoreOptionValidators,
 				},
 				optional: true,
 			},

--- a/src/rules/max-unique-animation-functions/index.ts
+++ b/src/rules/max-unique-animation-functions/index.ts
@@ -1,6 +1,6 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
-import { isAllowed as isIgnored } from '../../utils/allow-list.js'
+import { isAllowed } from '../../utils/allow-list.js'
 import { analyzeAnimation } from '@projectwallace/css-analyzer/values'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { OPERATOR } from '@projectwallace/css-parser'
@@ -62,7 +62,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 				for (let child of parsed.children) {
 					if (child.type !== OPERATOR) {
 						let fn = child.text
-						if (!isIgnored(fn, ignore)) {
+						if (!isAllowed(fn, ignore)) {
 							unique_functions.add(fn)
 						}
 					}
@@ -71,7 +71,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 				analyzeAnimation(parsed, function (item) {
 					if (item.type === 'fn') {
 						let fn = item.value.text
-						if (!isIgnored(fn, ignore)) {
+						if (!isAllowed(fn, ignore)) {
 							unique_functions.add(item.value.text)
 						}
 					}

--- a/src/rules/max-unique-box-shadows/index.ts
+++ b/src/rules/max-unique-box-shadows/index.ts
@@ -1,6 +1,6 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
-import { isAllowed } from '../../utils/allow-list.js'
+import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -31,10 +31,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignore: [
-						String as unknown as (v: unknown) => boolean,
-						(v: unknown) => v instanceof RegExp,
-					],
+					ignore: ignoreOptionValidators,
 				},
 				optional: true,
 			},

--- a/src/rules/max-unique-box-shadows/index.ts
+++ b/src/rules/max-unique-box-shadows/index.ts
@@ -1,6 +1,6 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
-import { isAllowed as isIgnored } from '../../utils/allow-list.js'
+import { isAllowed } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -52,7 +52,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			const before = unique_shadows.size
 			const value = declaration.value
 
-			if (!isIgnored(value, ignore)) {
+			if (!isAllowed(value, ignore)) {
 				unique_shadows.add(value)
 			}
 

--- a/src/rules/max-unique-colors/index.ts
+++ b/src/rules/max-unique-colors/index.ts
@@ -1,7 +1,7 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { namedColors, colorFunctions, colorKeywords } from '@projectwallace/css-analyzer/values'
-import { isAllowed as isIgnored } from '../../utils/allow-list.js'
+import { isAllowed } from '../../utils/allow-list.js'
 import {
 	parse_value,
 	walk,
@@ -88,14 +88,14 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 				if (is_hash(node)) {
 					const hash = node.text
 					// The parser already guarantees HASH nodes are valid hex colors.
-					if (!isIgnored(hash, ignore)) {
+					if (!isAllowed(hash, ignore)) {
 						unique_colors.add(hash)
 					}
 				} else if (is_identifier(node)) {
 					const ident = node.text
 					// namedColors and colorKeywords both perform case-insensitive matching.
 					if (namedColors.has(ident) || colorKeywords.has(ident)) {
-						if (!isIgnored(ident, ignore)) {
+						if (!isAllowed(ident, ignore)) {
 							unique_colors.add(ident)
 						}
 					}
@@ -108,7 +108,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 					if (colorFunctions.has(fn_name)) {
 						// Numeric-channel color functions (rgb, hsl, oklch, …).
 						// SKIP children — they are numbers, not color tokens.
-						if (!isIgnored(fn, ignore)) {
+						if (!isAllowed(fn, ignore)) {
 							unique_colors.add(fn)
 						}
 						return SKIP
@@ -119,7 +119,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 					if (COLOR_COMPOSING_FUNCTIONS.has(fn_name_lower)) {
 						// Composing color functions (color-mix, light-dark, device-cmyk) take
 						// color values as arguments. SKIP children so they are not double-counted.
-						if (!isIgnored(fn, ignore)) {
+						if (!isAllowed(fn, ignore)) {
 							unique_colors.add(node.text)
 						}
 						return SKIP
@@ -131,7 +131,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 						// any fallback color values are still evaluated.
 						const first = node.first_child
 						if (first !== null && is_identifier(first) && color_custom_properties.has(first.text)) {
-							if (!isIgnored(fn, ignore)) {
+							if (!isAllowed(fn, ignore)) {
 								unique_colors.add(fn)
 							}
 						}

--- a/src/rules/max-unique-colors/index.ts
+++ b/src/rules/max-unique-colors/index.ts
@@ -1,7 +1,7 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { namedColors, colorFunctions, colorKeywords } from '@projectwallace/css-analyzer/values'
-import { isAllowed } from '../../utils/allow-list.js'
+import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 import {
 	parse_value,
 	walk,
@@ -55,10 +55,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignore: [
-						String as unknown as (v: unknown) => boolean,
-						(v: unknown) => v instanceof RegExp,
-					],
+					ignore: ignoreOptionValidators,
 				},
 				optional: true,
 			},

--- a/src/rules/max-unique-durations/index.ts
+++ b/src/rules/max-unique-durations/index.ts
@@ -1,6 +1,6 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
-import { isAllowed as isIgnored } from '../../utils/allow-list.js'
+import { isAllowed } from '../../utils/allow-list.js'
 import { analyzeAnimation } from '@projectwallace/css-analyzer/values'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { OPERATOR } from '@projectwallace/css-parser'
@@ -60,7 +60,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 					if (child.type !== OPERATOR) {
 						let duration = child.text
 
-						if (!isIgnored(duration, ignore)) {
+						if (!isAllowed(duration, ignore)) {
 							unique_durations.add(duration)
 						}
 					}
@@ -69,7 +69,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 				analyzeAnimation(parsed, function (item) {
 					if (item.type === 'duration') {
 						let duration = item.value.text
-						if (!isIgnored(duration, ignore)) {
+						if (!isAllowed(duration, ignore)) {
 							unique_durations.add(duration)
 						}
 					}

--- a/src/rules/max-unique-durations/index.ts
+++ b/src/rules/max-unique-durations/index.ts
@@ -1,6 +1,6 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
-import { isAllowed } from '../../utils/allow-list.js'
+import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 import { analyzeAnimation } from '@projectwallace/css-analyzer/values'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { OPERATOR } from '@projectwallace/css-parser'
@@ -34,10 +34,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignore: [
-						String as unknown as (v: unknown) => boolean,
-						(v: unknown) => v instanceof RegExp,
-					],
+					ignore: ignoreOptionValidators,
 				},
 				optional: true,
 			},

--- a/src/rules/max-unique-font-families/README.md
+++ b/src/rules/max-unique-font-families/README.md
@@ -43,7 +43,7 @@ b { font: bold 16px Arial, sans-serif; }
 /* Both declarations share the same font-family value → only 1 unique entry */
 ```
 
-### `allowList` (optional)
+### `ignore` (optional)
 
 Type: `Array<string | RegExp>`
 
@@ -51,7 +51,7 @@ A list of font family values to exclude from the count. Each entry can be an exa
 
 Given:
 
-`[2, { "allowList": ["Arial, sans-serif"] }]`
+`[2, { "ignore": ["Arial, sans-serif"] }]`
 
 the following are _not_ considered violations:
 

--- a/src/rules/max-unique-font-families/index.test.ts
+++ b/src/rules/max-unique-font-families/index.test.ts
@@ -182,47 +182,47 @@ test('should not count font-size as a family', async () => {
 })
 
 // ---------------------------------------------------------------------------
-// allowList secondary option
+// ignore secondary option
 // ---------------------------------------------------------------------------
 
-test('should not count an exact string match in allowList', async () => {
+test('should not count an exact string match in ignore', async () => {
 	const { warnings, errored } = await lint(
 		`a { font-family: Arial; } b { font-family: Georgia; }`,
 		1,
-		{ allowList: ['Arial'] },
+		{ ignore: ['Arial'] },
 	)
 	// Arial is ignored → only Georgia counts → within limit
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not count values matching a RegExp in allowList', async () => {
+test('should not count values matching a RegExp in ignore', async () => {
 	const { warnings, errored } = await lint(
 		`a { font-family: Arial; } b { font-family: Georgia; } c { font-family: monospace; }`,
 		1,
-		{ allowList: [/^(Arial|Georgia)$/] },
+		{ ignore: [/^(Arial|Georgia)$/] },
 	)
 	// Arial and Georgia are ignored → only monospace counts → within limit
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not count allowListed values from font shorthand', async () => {
+test('should not count ignoreed values from font shorthand', async () => {
 	const { warnings, errored } = await lint(
 		`a { font: 16px Arial; } b { font-family: Georgia; }`,
 		1,
-		{ allowList: ['Arial'] },
+		{ ignore: ['Arial'] },
 	)
 	// Arial (from font shorthand) is ignored → only Georgia counts
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
 
-test('should still count non-allowListed values', async () => {
+test('should still count non-ignoreed values', async () => {
 	const { warnings, errored } = await lint(
 		`a { font-family: Arial; } b { font-family: Georgia; }`,
 		1,
-		{ allowList: ['Arial'] },
+		{ ignore: ['Arial'] },
 	)
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
@@ -251,14 +251,14 @@ test('should not count font-family inside @font-face but still count outside', a
 })
 
 // ---------------------------------------------------------------------------
-// allowList secondary option (continued)
+// ignore secondary option (continued)
 // ---------------------------------------------------------------------------
 
-test('should error when non-allowListed values exceed the limit', async () => {
+test('should error when non-ignoreed values exceed the limit', async () => {
 	const { warnings, errored } = await lint(
 		`a { font-family: Arial; } b { font-family: Georgia; } c { font-family: monospace; }`,
 		1,
-		{ allowList: ['Arial'] },
+		{ ignore: ['Arial'] },
 	)
 	// Arial ignored → Georgia + monospace = 2 → exceeds limit of 1
 	expect(errored).toBe(true)

--- a/src/rules/max-unique-font-families/index.ts
+++ b/src/rules/max-unique-font-families/index.ts
@@ -18,7 +18,7 @@ const meta = {
 }
 
 interface SecondaryOptions {
-	allowList?: Array<string | RegExp>
+	ignore?: Array<string | RegExp>
 }
 
 const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions) => {
@@ -33,7 +33,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			{
 				actual: secondaryOptions,
 				possible: {
-					allowList: [
+					ignore: [
 						String as unknown as (v: unknown) => boolean,
 						(v: unknown) => v instanceof RegExp,
 					],
@@ -46,7 +46,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			return
 		}
 
-		const allowList = secondaryOptions?.allowList ?? []
+		const ignore = secondaryOptions?.ignore ?? []
 		const unique_families = new Set<string>()
 		const violating_declarations: Declaration[] = []
 
@@ -58,7 +58,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 				return
 			}
 			const before = unique_families.size
-			if (!isAllowed(declaration.value, allowList)) {
+			if (!isAllowed(declaration.value, ignore)) {
 				unique_families.add(declaration.value)
 			}
 			if (unique_families.size > before && unique_families.size > primaryOption) {
@@ -70,7 +70,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			const before = unique_families.size
 			const parsed = parse_value(declaration.value)
 			const destructured = destructureFontShorthand(parsed, () => {})
-			if (destructured?.font_family && !isAllowed(destructured.font_family, allowList)) {
+			if (destructured?.font_family && !isAllowed(destructured.font_family, ignore)) {
 				unique_families.add(destructured.font_family)
 			}
 			if (unique_families.size > before && unique_families.size > primaryOption) {

--- a/src/rules/max-unique-font-families/index.ts
+++ b/src/rules/max-unique-font-families/index.ts
@@ -2,7 +2,7 @@ import stylelint from 'stylelint'
 import type { Root, Declaration, AtRule } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { destructureFontShorthand } from '@projectwallace/css-analyzer/values'
-import { isAllowed } from '../../utils/allow-list.js'
+import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -33,10 +33,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignore: [
-						String as unknown as (v: unknown) => boolean,
-						(v: unknown) => v instanceof RegExp,
-					],
+					ignore: ignoreOptionValidators,
 				},
 				optional: true,
 			},

--- a/src/rules/max-unique-font-sizes/README.md
+++ b/src/rules/max-unique-font-sizes/README.md
@@ -43,7 +43,7 @@ b { font: bold 16px Arial, sans-serif; }
 /* Both declarations share the same font-size value → only 1 unique entry */
 ```
 
-### `allowList` (optional)
+### `ignore` (optional)
 
 Type: `Array<string | RegExp>`
 
@@ -51,7 +51,7 @@ A list of font size values to exclude from the count. Each entry can be an exact
 
 Given:
 
-`[2, { "allowList": ["16px"] }]`
+`[2, { "ignore": ["16px"] }]`
 
 the following are _not_ considered violations:
 

--- a/src/rules/max-unique-font-sizes/index.test.ts
+++ b/src/rules/max-unique-font-sizes/index.test.ts
@@ -167,43 +167,43 @@ test('should not count font-family as a size', async () => {
 })
 
 // ---------------------------------------------------------------------------
-// allowList secondary option
+// ignore secondary option
 // ---------------------------------------------------------------------------
 
-test('should not count an exact string match in allowList', async () => {
+test('should not count an exact string match in ignore', async () => {
 	const { warnings, errored } = await lint(`a { font-size: 16px; } b { font-size: 24px; }`, 1, {
-		allowList: ['16px'],
+		ignore: ['16px'],
 	})
 	// 16px is ignored → only 24px counts → within limit
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not count values matching a RegExp in allowList', async () => {
+test('should not count values matching a RegExp in ignore', async () => {
 	const { warnings, errored } = await lint(
 		`a { font-size: 12px; } b { font-size: 16px; } c { font-size: 24px; }`,
 		1,
-		{ allowList: [/^(12px|16px)$/] },
+		{ ignore: [/^(12px|16px)$/] },
 	)
 	// 12px and 16px are ignored → only 24px counts → within limit
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not count allowListed values from font shorthand', async () => {
+test('should not count ignoreed values from font shorthand', async () => {
 	const { warnings, errored } = await lint(`a { font: 16px Arial; } b { font-size: 24px; }`, 1, {
-		allowList: ['16px'],
+		ignore: ['16px'],
 	})
 	// 16px (from font shorthand) is ignored → only 24px counts
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
 
-test('should error when non-allowListed values exceed the limit', async () => {
+test('should error when non-ignoreed values exceed the limit', async () => {
 	const { warnings, errored } = await lint(
 		`a { font-size: 12px; } b { font-size: 16px; } c { font-size: 24px; }`,
 		1,
-		{ allowList: ['12px'] },
+		{ ignore: ['12px'] },
 	)
 	// 12px ignored → 16px + 24px = 2 → exceeds limit of 1
 	expect(errored).toBe(true)

--- a/src/rules/max-unique-font-sizes/index.ts
+++ b/src/rules/max-unique-font-sizes/index.ts
@@ -2,7 +2,7 @@ import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { destructureFontShorthand } from '@projectwallace/css-analyzer/values'
-import { isAllowed } from '../../utils/allow-list.js'
+import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -33,10 +33,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignore: [
-						String as unknown as (v: unknown) => boolean,
-						(v: unknown) => v instanceof RegExp,
-					],
+					ignore: ignoreOptionValidators,
 				},
 				optional: true,
 			},

--- a/src/rules/max-unique-font-sizes/index.ts
+++ b/src/rules/max-unique-font-sizes/index.ts
@@ -18,7 +18,7 @@ const meta = {
 }
 
 interface SecondaryOptions {
-	allowList?: Array<string | RegExp>
+	ignore?: Array<string | RegExp>
 }
 
 const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions) => {
@@ -33,7 +33,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			{
 				actual: secondaryOptions,
 				possible: {
-					allowList: [
+					ignore: [
 						String as unknown as (v: unknown) => boolean,
 						(v: unknown) => v instanceof RegExp,
 					],
@@ -46,13 +46,13 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			return
 		}
 
-		const allowList = secondaryOptions?.allowList ?? []
+		const ignore = secondaryOptions?.ignore ?? []
 		const unique_sizes = new Set<string>()
 		const violating_declarations: Declaration[] = []
 
 		root.walkDecls('font-size', (declaration) => {
 			const before = unique_sizes.size
-			if (!isAllowed(declaration.value, allowList)) {
+			if (!isAllowed(declaration.value, ignore)) {
 				unique_sizes.add(declaration.value)
 			}
 			if (unique_sizes.size > before && unique_sizes.size > primaryOption) {
@@ -64,7 +64,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			const before = unique_sizes.size
 			const parsed = parse_value(declaration.value)
 			const destructured = destructureFontShorthand(parsed, () => {})
-			if (destructured?.font_size && !isAllowed(destructured.font_size, allowList)) {
+			if (destructured?.font_size && !isAllowed(destructured.font_size, ignore)) {
 				unique_sizes.add(destructured.font_size)
 			}
 			if (unique_sizes.size > before && unique_sizes.size > primaryOption) {

--- a/src/rules/max-unique-gradients/index.ts
+++ b/src/rules/max-unique-gradients/index.ts
@@ -2,7 +2,7 @@ import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { walk } from '@projectwallace/css-parser/walker'
-import { isAllowed as isIgnored } from '../../utils/allow-list.js'
+import { isAllowed } from '../../utils/allow-list.js'
 import { is_function } from '@projectwallace/css-parser'
 
 const { createPlugin, utils } = stylelint
@@ -60,7 +60,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 					if (/^(repeating-)?(linear|conic|radial)-gradient$/.test(node.name)) {
 						const gradient = node.text
 
-						if (!isIgnored(gradient, ignore)) {
+						if (!isAllowed(gradient, ignore)) {
 							unique_gradients.add(gradient)
 						}
 					}

--- a/src/rules/max-unique-gradients/index.ts
+++ b/src/rules/max-unique-gradients/index.ts
@@ -2,7 +2,7 @@ import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { walk } from '@projectwallace/css-parser/walker'
-import { isAllowed } from '../../utils/allow-list.js'
+import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 import { is_function } from '@projectwallace/css-parser'
 
 const { createPlugin, utils } = stylelint
@@ -34,10 +34,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignore: [
-						String as unknown as (v: unknown) => boolean,
-						(v: unknown) => v instanceof RegExp,
-					],
+					ignore: ignoreOptionValidators,
 				},
 				optional: true,
 			},

--- a/src/rules/no-property-shorthand/README.md
+++ b/src/rules/no-property-shorthand/README.md
@@ -34,16 +34,16 @@ a {
 
 ## Options
 
-### `allowList: Array<string | RegExp>`
+### `ignore: Array<string | RegExp>`
 
 Allows specific shorthand properties to be used. Accepts exact strings or regular expressions.
 
 <!-- prettier-ignore -->
 ```json
-[true, { "allowList": ["background", "/^border-/"] }]
+[true, { "ignore": ["background", "/^border-/"] }]
 ```
 
-The following are _not_ considered violations when `allowList: ["background"]` is set:
+The following are _not_ considered violations when `ignore: ["background"]` is set:
 
 <!-- prettier-ignore -->
 ```css

--- a/src/rules/no-property-shorthand/index.test.ts
+++ b/src/rules/no-property-shorthand/index.test.ts
@@ -103,7 +103,7 @@ test('should match shorthand properties case-insensitively', async () => {
 	expect(warnings).toHaveLength(1)
 })
 
-test('should not error when a shorthand is in the allowList (string)', async () => {
+test('should not error when a shorthand is in the ignore (string)', async () => {
 	const {
 		results: [{ warnings, errored }],
 	} = await stylelint.lint({
@@ -111,7 +111,7 @@ test('should not error when a shorthand is in the allowList (string)', async () 
 		config: {
 			plugins: [plugin],
 			rules: {
-				[rule_name]: [true, { allowList: ['background'] }],
+				[rule_name]: [true, { ignore: ['background'] }],
 			},
 		},
 	})
@@ -120,7 +120,7 @@ test('should not error when a shorthand is in the allowList (string)', async () 
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not error when a shorthand matches an allowList RegExp', async () => {
+test('should not error when a shorthand matches an ignore RegExp', async () => {
 	const {
 		results: [{ warnings, errored }],
 	} = await stylelint.lint({
@@ -128,7 +128,7 @@ test('should not error when a shorthand matches an allowList RegExp', async () =
 		config: {
 			plugins: [plugin],
 			rules: {
-				[rule_name]: [true, { allowList: [/^border-/] }],
+				[rule_name]: [true, { ignore: [/^border-/] }],
 			},
 		},
 	})
@@ -137,7 +137,7 @@ test('should not error when a shorthand matches an allowList RegExp', async () =
 	expect(warnings).toStrictEqual([])
 })
 
-test('should still error on shorthands not in the allowList', async () => {
+test('should still error on shorthands not in the ignore', async () => {
 	const {
 		results: [{ warnings, errored }],
 	} = await stylelint.lint({
@@ -145,7 +145,7 @@ test('should still error on shorthands not in the allowList', async () => {
 		config: {
 			plugins: [plugin],
 			rules: {
-				[rule_name]: [true, { allowList: ['background'] }],
+				[rule_name]: [true, { ignore: ['background'] }],
 			},
 		},
 	})

--- a/src/rules/no-property-shorthand/index.ts
+++ b/src/rules/no-property-shorthand/index.ts
@@ -16,7 +16,7 @@ const meta = {
 }
 
 interface SecondaryOptions {
-	allowList?: Array<string | RegExp>
+	ignore?: Array<string | RegExp>
 }
 
 const ruleFunction = (primaryOption: true, secondaryOptions?: SecondaryOptions) => {
@@ -33,7 +33,7 @@ const ruleFunction = (primaryOption: true, secondaryOptions?: SecondaryOptions) 
 		root.walkDecls((declaration) => {
 			const property = declaration.prop.toLowerCase()
 			if (!shorthand_properties.has(property)) return
-			if (secondaryOptions?.allowList && isAllowed(property, secondaryOptions.allowList)) return
+			if (secondaryOptions?.ignore && isAllowed(property, secondaryOptions.ignore)) return
 
 			utils.report({
 				message: messages.rejected(declaration.prop),

--- a/src/rules/no-unknown-container-names/README.md
+++ b/src/rules/no-unknown-container-names/README.md
@@ -57,7 +57,7 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `allowList: [/regex/, "non-regex"]`
+### `ignore: [/regex/, "non-regex"]`
 
 Allow specific container names that are used in `@container` queries but not declared in the stylesheet. Useful for container names defined in another stylesheet or by an external system.
 

--- a/src/rules/no-unknown-container-names/index.test.ts
+++ b/src/rules/no-unknown-container-names/index.test.ts
@@ -226,11 +226,11 @@ test('should not error on @container with scroll-state query', async () => {
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not error on unknown name matched by allowList string', async () => {
+test('should not error on unknown name matched by ignore string', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: [true, { allowList: ['sidebar'] }],
+			[rule_name]: [true, { ignore: ['sidebar'] }],
 		},
 	}
 
@@ -245,11 +245,11 @@ test('should not error on unknown name matched by allowList string', async () =>
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not error on unknown name matched by allowList RegExp', async () => {
+test('should not error on unknown name matched by ignore RegExp', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: [true, { allowList: [/^side/] }],
+			[rule_name]: [true, { ignore: [/^side/] }],
 		},
 	}
 
@@ -264,11 +264,11 @@ test('should not error on unknown name matched by allowList RegExp', async () =>
 	expect(warnings).toStrictEqual([])
 })
 
-test('should still error when allowList does not match the unknown container name', async () => {
+test('should still error when ignore does not match the unknown container name', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: [true, { allowList: ['header'] }],
+			[rule_name]: [true, { ignore: ['header'] }],
 		},
 	}
 

--- a/src/rules/no-unknown-container-names/index.ts
+++ b/src/rules/no-unknown-container-names/index.ts
@@ -20,7 +20,7 @@ const meta = {
 }
 
 interface SecondaryOptions {
-	allowList?: Array<string | RegExp>
+	ignore?: Array<string | RegExp>
 }
 
 const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions) => {
@@ -40,7 +40,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 		for (const usage of usages) {
 			if (declared_names.has(usage.name)) continue
 
-			if (secondaryOptions?.allowList && isAllowed(usage.name, secondaryOptions.allowList)) continue
+			if (secondaryOptions?.ignore && isAllowed(usage.name, secondaryOptions.ignore)) continue
 
 			utils.report({
 				result,

--- a/src/rules/no-unknown-custom-property/README.md
+++ b/src/rules/no-unknown-custom-property/README.md
@@ -47,7 +47,7 @@ a {
 
 ## Optional secondary options
 
-### `allowList: [/regex/, "non-regex"]`
+### `ignore: [/regex/, "non-regex"]`
 
 Allow specific undeclared custom properties by exact string or RegExp pattern. Useful for custom properties defined externally (e.g. design tokens, theming systems) that are not declared in the stylesheet being linted.
 

--- a/src/rules/no-unknown-custom-property/index.test.ts
+++ b/src/rules/no-unknown-custom-property/index.test.ts
@@ -208,11 +208,11 @@ test('should not error on undeclared var() with empty fallback when allowFallbac
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not error on undeclared property matched by allowList string', async () => {
+test('should not error on undeclared property matched by ignore string', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: [true, { allowList: ['--external-color'] }],
+			[rule_name]: [true, { ignore: ['--external-color'] }],
 		},
 	}
 
@@ -227,11 +227,11 @@ test('should not error on undeclared property matched by allowList string', asyn
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not error on undeclared property matched by allowList RegExp', async () => {
+test('should not error on undeclared property matched by ignore RegExp', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: [true, { allowList: [/^--external-/] }],
+			[rule_name]: [true, { ignore: [/^--external-/] }],
 		},
 	}
 
@@ -246,11 +246,11 @@ test('should not error on undeclared property matched by allowList RegExp', asyn
 	expect(warnings).toStrictEqual([])
 })
 
-test('should still error on undeclared property not matched by allowList', async () => {
+test('should still error on undeclared property not matched by ignore', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: [true, { allowList: ['--external-color'] }],
+			[rule_name]: [true, { ignore: ['--external-color'] }],
 		},
 	}
 
@@ -268,11 +268,11 @@ test('should still error on undeclared property not matched by allowList', async
 	)
 })
 
-test('ignores allowList when entries have incorrect types', async () => {
+test('ignores ignore when entries have incorrect types', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: [true, { allowList: [false] }],
+			[rule_name]: [true, { ignore: [false] }],
 		},
 	}
 

--- a/src/rules/no-unknown-custom-property/index.ts
+++ b/src/rules/no-unknown-custom-property/index.ts
@@ -19,7 +19,7 @@ const meta = {
 
 interface SecondaryOptions {
 	allowFallback?: boolean
-	allowList?: Array<string | RegExp>
+	ignore?: Array<string | RegExp>
 	importFrom?: ImportFrom[]
 }
 
@@ -46,7 +46,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 			if (declared_properties.has(usage.name)) continue
 			if (imported_properties?.has(usage.name)) continue
 			if (secondaryOptions?.allowFallback && usage.has_fallback) continue
-			if (secondaryOptions?.allowList && isAllowed(usage.name, secondaryOptions.allowList)) continue
+			if (secondaryOptions?.ignore && isAllowed(usage.name, secondaryOptions.ignore)) continue
 
 			utils.report({
 				result,

--- a/src/rules/no-unused-container-names/README.md
+++ b/src/rules/no-unused-container-names/README.md
@@ -58,7 +58,7 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `allowList: [/regex/, "non-regex"]`
+### `ignore: [/regex/, "non-regex"]`
 
 Allow specific container names that are declared but never queried. Useful for container names intended to be queried in other stylesheets or by external tools.
 

--- a/src/rules/no-unused-container-names/index.test.ts
+++ b/src/rules/no-unused-container-names/index.test.ts
@@ -245,11 +245,11 @@ test('should not error on anonymous @container queries', async () => {
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not error when allowList string matches unused container name', async () => {
+test('should not error when ignore string matches unused container name', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: [true, { allowList: ['sidebar'] }],
+			[rule_name]: [true, { ignore: ['sidebar'] }],
 		},
 	}
 
@@ -264,11 +264,11 @@ test('should not error when allowList string matches unused container name', asy
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not error when allowList RegExp matches unused container name', async () => {
+test('should not error when ignore RegExp matches unused container name', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: [true, { allowList: [/^side/] }],
+			[rule_name]: [true, { ignore: [/^side/] }],
 		},
 	}
 
@@ -283,11 +283,11 @@ test('should not error when allowList RegExp matches unused container name', asy
 	expect(warnings).toStrictEqual([])
 })
 
-test('should still error when allowList does not match the unused container name', async () => {
+test('should still error when ignore does not match the unused container name', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
-			[rule_name]: [true, { allowList: ['header'] }],
+			[rule_name]: [true, { ignore: ['header'] }],
 		},
 	}
 

--- a/src/rules/no-unused-container-names/index.ts
+++ b/src/rules/no-unused-container-names/index.ts
@@ -20,7 +20,7 @@ const meta = {
 }
 
 interface SecondaryOptions {
-	allowList?: Array<string | RegExp>
+	ignore?: Array<string | RegExp>
 }
 
 const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions) => {
@@ -40,7 +40,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 		for (const [name, node] of declared_names) {
 			if (used_names.has(name)) continue
 
-			if (secondaryOptions?.allowList && isAllowed(name, secondaryOptions.allowList)) continue
+			if (secondaryOptions?.ignore && isAllowed(name, secondaryOptions.ignore)) continue
 
 			utils.report({
 				result,

--- a/src/rules/no-unused-custom-properties/README.md
+++ b/src/rules/no-unused-custom-properties/README.md
@@ -45,7 +45,7 @@ a {
 
 ## Optional secondary options
 
-### `ignoreProperties: [/regex/, "non-regex"]`
+### `ignore: [/regex/, "non-regex"]`
 
 Ignore specific unused custom properties.
 

--- a/src/rules/no-unused-custom-properties/index.test.ts
+++ b/src/rules/no-unused-custom-properties/index.test.ts
@@ -122,14 +122,14 @@ test('should error on a single unused custom property', async () => {
 	expect(column).toBe(5)
 })
 
-test('should not error on when an unused custom property is allowed in options.ignoreProperties (string)', async () => {
+test('should not error on when an unused custom property is allowed in options.ignore (string)', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
 			[rule_name]: [
 				true,
 				{
-					ignoreProperties: ['--ignored'],
+					ignore: ['--ignored'],
 				},
 			],
 		},
@@ -146,14 +146,14 @@ test('should not error on when an unused custom property is allowed in options.i
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not error on when an unused custom property is allowed in options.ignoreProperties (RegExp)', async () => {
+test('should not error on when an unused custom property is allowed in options.ignore (RegExp)', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
 			[rule_name]: [
 				true,
 				{
-					ignoreProperties: [/regex/],
+					ignore: [/regex/],
 				},
 			],
 		},
@@ -222,14 +222,14 @@ test('should error when a custom property declared via @property is never used',
 	)
 })
 
-test('ignores options when options.ignoreProperties types are incorrect', async () => {
+test('ignores options when options.ignore types are incorrect', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
 			[rule_name]: [
 				true,
 				{
-					ignoreProperties: [false],
+					ignore: [false],
 				},
 			],
 		},

--- a/src/rules/no-unused-custom-properties/index.ts
+++ b/src/rules/no-unused-custom-properties/index.ts
@@ -1,6 +1,7 @@
 import stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { collect_declared_properties, collect_var_usages } from '../../utils/custom-properties.js'
+import { isAllowed } from '../../utils/allow-list.js'
 import { collect_usages_from_files } from '../../utils/import-from.js'
 import type { ImportFrom } from '../../utils/import-from.js'
 
@@ -17,7 +18,7 @@ const meta = {
 }
 
 interface SecondaryOptions {
-	ignoreProperties?: Array<string | RegExp>
+	ignore?: Array<string | RegExp>
 	importFrom?: ImportFrom[]
 }
 
@@ -44,14 +45,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 		for (const [prop, node] of declared_properties) {
 			if (used_names.has(prop)) continue
 
-			if (secondaryOptions?.ignoreProperties) {
-				const ignored = secondaryOptions.ignoreProperties.some(
-					(pattern) =>
-						(typeof pattern === 'string' && pattern === prop) ||
-						(pattern instanceof RegExp && pattern.test(prop)),
-				)
-				if (ignored) continue
-			}
+			if (secondaryOptions?.ignore && isAllowed(prop, secondaryOptions.ignore)) continue
 
 			utils.report({
 				result,

--- a/src/rules/no-unused-layers/README.md
+++ b/src/rules/no-unused-layers/README.md
@@ -48,7 +48,7 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `allowlist: [/regex/, "non-regex"]`
+### `ignore: [/regex/, "non-regex"]`
 
 Ignore specific layer names that are declared but not defined. This is useful for layers that are intentionally defined in external stylesheets (e.g. third-party resets).
 

--- a/src/rules/no-unused-layers/index.test.ts
+++ b/src/rules/no-unused-layers/index.test.ts
@@ -137,14 +137,14 @@ test('should error for each undeclared layer in a list', async () => {
 	expect(warnings.length).toBe(3)
 })
 
-test('should not error when an unused layer is in the allowlist (string)', async () => {
+test('should not error when an unused layer is in the ignore (string)', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
 			[rule_name]: [
 				true,
 				{
-					allowlist: ['utilities'],
+					ignore: ['utilities'],
 				},
 			],
 		},
@@ -164,14 +164,14 @@ test('should not error when an unused layer is in the allowlist (string)', async
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not error when an unused layer matches the allowlist (RegExp)', async () => {
+test('should not error when an unused layer matches the ignore (RegExp)', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
 			[rule_name]: [
 				true,
 				{
-					allowlist: [/^vendor-/],
+					ignore: [/^vendor-/],
 				},
 			],
 		},
@@ -191,14 +191,14 @@ test('should not error when an unused layer matches the allowlist (RegExp)', asy
 	expect(warnings).toStrictEqual([])
 })
 
-test('should still error for layers not in the allowlist when allowlist is set', async () => {
+test('should still error for layers not in the ignore when ignore is set', async () => {
 	const config = {
 		plugins: [plugin],
 		rules: {
 			[rule_name]: [
 				true,
 				{
-					allowlist: ['utilities'],
+					ignore: ['utilities'],
 				},
 			],
 		},

--- a/src/rules/no-unused-layers/index.ts
+++ b/src/rules/no-unused-layers/index.ts
@@ -15,7 +15,7 @@ const meta = {
 }
 
 interface SecondaryOptions {
-	allowlist?: Array<string | RegExp>
+	ignore?: Array<string | RegExp>
 }
 
 const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions) => {
@@ -55,7 +55,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 
 		for (const [layer, node] of declared_layers) {
 			if (defined_layers.has(layer)) continue
-			if (secondaryOptions?.allowlist && isAllowed(layer, secondaryOptions.allowlist)) continue
+			if (secondaryOptions?.ignore && isAllowed(layer, secondaryOptions.ignore)) continue
 
 			utils.report({
 				result,

--- a/src/rules/no-useless-custom-property-assignment/README.md
+++ b/src/rules/no-useless-custom-property-assignment/README.md
@@ -59,7 +59,7 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `allowList: [/regex/, "non-regex"]`
+### `ignore: [/regex/, "non-regex"]`
 
 Allow specific custom properties to be exempt from this rule, by exact string or RegExp pattern.
 

--- a/src/rules/no-useless-custom-property-assignment/index.test.ts
+++ b/src/rules/no-useless-custom-property-assignment/index.test.ts
@@ -92,7 +92,7 @@ test('should only report once even if the same self-reference appears multiple t
 	expect(warnings.length).toBe(1)
 })
 
-test('should not error when allowList matches the property as a string', async () => {
+test('should not error when ignore matches the property as a string', async () => {
 	const {
 		results: [{ warnings, errored }],
 	} = await stylelint.lint({
@@ -100,7 +100,7 @@ test('should not error when allowList matches the property as a string', async (
 		config: {
 			plugins: [plugin],
 			rules: {
-				[rule_name]: [true, { allowList: ['--color'] }],
+				[rule_name]: [true, { ignore: ['--color'] }],
 			},
 		},
 	})
@@ -109,7 +109,7 @@ test('should not error when allowList matches the property as a string', async (
 	expect(warnings).toStrictEqual([])
 })
 
-test('should not error when allowList matches the property as a RegExp', async () => {
+test('should not error when ignore matches the property as a RegExp', async () => {
 	const {
 		results: [{ warnings, errored }],
 	} = await stylelint.lint({
@@ -117,7 +117,7 @@ test('should not error when allowList matches the property as a RegExp', async (
 		config: {
 			plugins: [plugin],
 			rules: {
-				[rule_name]: [true, { allowList: [/^--color-/] }],
+				[rule_name]: [true, { ignore: [/^--color-/] }],
 			},
 		},
 	})
@@ -126,7 +126,7 @@ test('should not error when allowList matches the property as a RegExp', async (
 	expect(warnings).toStrictEqual([])
 })
 
-test('should still error on self-assignment not matched by allowList', async () => {
+test('should still error on self-assignment not matched by ignore', async () => {
 	const {
 		results: [{ warnings, errored }],
 	} = await stylelint.lint({
@@ -134,7 +134,7 @@ test('should still error on self-assignment not matched by allowList', async () 
 		config: {
 			plugins: [plugin],
 			rules: {
-				[rule_name]: [true, { allowList: ['--color'] }],
+				[rule_name]: [true, { ignore: ['--color'] }],
 			},
 		},
 	})

--- a/src/rules/no-useless-custom-property-assignment/index.ts
+++ b/src/rules/no-useless-custom-property-assignment/index.ts
@@ -19,7 +19,7 @@ const meta = {
 }
 
 interface SecondaryOptions {
-	allowList?: Array<string | RegExp>
+	ignore?: Array<string | RegExp>
 }
 
 const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions) => {
@@ -36,7 +36,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 		root.walkDecls(/^--/, (decl) => {
 			const property = decl.prop
 
-			if (secondaryOptions?.allowList && isAllowed(property, secondaryOptions.allowList)) return
+			if (secondaryOptions?.ignore && isAllowed(property, secondaryOptions.ignore)) return
 
 			const parsed = parse_value(decl.value)
 

--- a/src/utils/allow-list.ts
+++ b/src/utils/allow-list.ts
@@ -1,7 +1,3 @@
-/**
- * Check if a given value matches any pattern in an allowList.
- * Each pattern can be an exact string or a RegExp.
- */
 export function isAllowed(value: string, allowList: Array<string | RegExp>): boolean {
 	return allowList.some(
 		(pattern) =>
@@ -9,3 +5,8 @@ export function isAllowed(value: string, allowList: Array<string | RegExp>): boo
 			(pattern instanceof RegExp && pattern.test(value)),
 	)
 }
+
+export const ignoreOptionValidators: Array<(v: unknown) => boolean> = [
+	String as unknown as (v: unknown) => boolean,
+	(v: unknown) => v instanceof RegExp,
+]


### PR DESCRIPTION
closes #140 


**Option renamed to `ignore` across 9 rules** (source, tests, and docs):

| Rule | Old option | Change |
|---|---|---|
| `max-unique-font-families` | `allowList` | renamed |
| `max-unique-font-sizes` | `allowList` | renamed |
| `no-property-shorthand` | `allowList` | renamed |
| `no-unknown-container-names` | `allowList` | renamed |
| `no-unused-container-names` | `allowList` | renamed |
| `no-unknown-custom-property` | `allowList` | renamed |
| `no-useless-custom-property-assignment` | `allowList` | renamed |
| `no-unused-layers` | `allowlist` | renamed + casing fixed |
| `no-unused-custom-properties` | `ignoreProperties` | renamed + inline impl replaced with `isAllowed` |

**Import alias cleaned up in 5 rules** (`max-unique-box-shadows`, `durations`, `animation-functions`, `colors`, `gradients`): `isAllowed as isIgnored` → `isAllowed` directly.
