### PR TITLE
fix: ignore keywords when analyzing design tokens

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,46 @@ if (!isAllowed(value, ignore)) {
 }
 ```
 
+## Testing conventions
+
+**`lint()` helper** — rules with a primary option use a shared async helper so each test only passes the CSS and options:
+
+```ts
+async function lint(code: string, primaryOption: unknown, secondaryOptions?: unknown) {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]:
+				secondaryOptions !== undefined ? [primaryOption, secondaryOptions] : primaryOption,
+		},
+	}
+	const {
+		results: [result],
+	} = await stylelint.lint({ code, config })
+	return result
+}
+```
+
+**Section headers** — group tests with 75-dash divider comments:
+
+```ts
+// ---------------------------------------------------------------------------
+// No violation
+// ---------------------------------------------------------------------------
+```
+
+**Test naming** — use the following prefixes consistently:
+
+- `should not run when …` — for invalid/disabled config (option validation)
+- `should not error when …` — for valid CSS that passes the rule
+- `should error when …` — for CSS that triggers a violation
+
+**Assertions** — always check both `errored` and `warnings` together. Use `toStrictEqual([])` for empty warnings.
+
+**`ignore` option tests** — whenever a rule supports the `ignore` secondary option, cover both a plain string match and a `RegExp` pattern in the tests.
+
+**`test.each`** — use `test.each([])` instead of individual `test()` calls when testing multiple similar inputs (e.g. a list of CSS keywords or property values). This keeps test files concise.
+
 ## Adding a new config
 
 1. Create a new file under `src/configs/<config-name>.ts`

--- a/src/rules/max-unique-box-shadows/index.test.ts
+++ b/src/rules/max-unique-box-shadows/index.test.ts
@@ -212,3 +212,26 @@ test('should support RegExp patterns in ignore', async () => {
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
+
+// ---------------------------------------------------------------------------
+// CSS keywords
+// ---------------------------------------------------------------------------
+
+test.each(['none', 'inherit', 'initial', 'unset', 'revert', 'revert-layer'])(
+	'should not count %s as a unique box shadow',
+	async (keyword) => {
+		const { warnings, errored } = await lint(`a { box-shadow: ${keyword}; }`, 1)
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test('should count design token shadows while ignoring keywords mixed in', async () => {
+	const { warnings, errored } = await lint(
+		`a { box-shadow: 0 2px 4px red; } b { box-shadow: none; } c { box-shadow: 0 4px 8px blue; }`,
+		1,
+	)
+	// none is a keyword and is not counted → 2 unique shadows → exceeds limit of 1
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique box shadows')
+})

--- a/src/rules/max-unique-box-shadows/index.ts
+++ b/src/rules/max-unique-box-shadows/index.ts
@@ -1,5 +1,6 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
+import { keywords } from '@projectwallace/css-analyzer/values'
 import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
@@ -49,7 +50,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 			const before = unique_shadows.size
 			const value = declaration.value
 
-			if (!isAllowed(value, ignore)) {
+			if (!keywords.has(value) && !isAllowed(value, ignore)) {
 				unique_shadows.add(value)
 			}
 

--- a/src/rules/max-unique-durations/index.test.ts
+++ b/src/rules/max-unique-durations/index.test.ts
@@ -237,3 +237,26 @@ test('should support RegExp patterns in ignore', async () => {
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
+
+// ---------------------------------------------------------------------------
+// CSS keywords
+// ---------------------------------------------------------------------------
+
+test.each(['inherit', 'initial', 'unset', 'revert', 'revert-layer'])(
+	'should not count %s as a unique duration',
+	async (keyword) => {
+		const { warnings, errored } = await lint(`a { animation-duration: ${keyword}; }`, 1)
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test('should count design token durations while ignoring keywords mixed in', async () => {
+	const { warnings, errored } = await lint(
+		`a { animation-duration: 1s; } b { animation-duration: inherit; } c { animation-duration: 2s; }`,
+		1,
+	)
+	// inherit is a keyword and is not counted → 1s + 2s = 2 → exceeds limit of 1
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique durations')
+})

--- a/src/rules/max-unique-durations/index.ts
+++ b/src/rules/max-unique-durations/index.ts
@@ -1,7 +1,7 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
-import { analyzeAnimation } from '@projectwallace/css-analyzer/values'
+import { analyzeAnimation, keywords } from '@projectwallace/css-analyzer/values'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { OPERATOR } from '@projectwallace/css-parser'
 
@@ -57,7 +57,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 					if (child.type !== OPERATOR) {
 						let duration = child.text
 
-						if (!isAllowed(duration, ignore)) {
+						if (!keywords.has(duration) && !isAllowed(duration, ignore)) {
 							unique_durations.add(duration)
 						}
 					}

--- a/src/rules/max-unique-font-families/index.test.ts
+++ b/src/rules/max-unique-font-families/index.test.ts
@@ -264,3 +264,26 @@ test('should error when non-ignoreed values exceed the limit', async () => {
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toContain('Found 2 unique font families')
 })
+
+// ---------------------------------------------------------------------------
+// CSS keywords
+// ---------------------------------------------------------------------------
+
+test.each(['inherit', 'initial', 'unset', 'revert', 'revert-layer'])(
+	'should not count %s as a unique font family',
+	async (keyword) => {
+		const { warnings, errored } = await lint(`a { font-family: ${keyword}; }`, 0)
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test('should count design token families while ignoring keywords mixed in', async () => {
+	const { warnings, errored } = await lint(
+		`a { font-family: Arial; } b { font-family: inherit; } c { font-family: Georgia; }`,
+		1,
+	)
+	// inherit is a keyword and is not counted → Arial + Georgia = 2 → exceeds limit of 1
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique font families')
+})

--- a/src/rules/max-unique-font-families/index.ts
+++ b/src/rules/max-unique-font-families/index.ts
@@ -1,7 +1,7 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration, AtRule } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
-import { destructureFontShorthand } from '@projectwallace/css-analyzer/values'
+import { destructureFontShorthand, keywords } from '@projectwallace/css-analyzer/values'
 import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
@@ -55,7 +55,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 				return
 			}
 			const before = unique_families.size
-			if (!isAllowed(declaration.value, ignore)) {
+			if (!keywords.has(declaration.value) && !isAllowed(declaration.value, ignore)) {
 				unique_families.add(declaration.value)
 			}
 			if (unique_families.size > before && unique_families.size > primaryOption) {

--- a/src/rules/max-unique-font-sizes/index.test.ts
+++ b/src/rules/max-unique-font-sizes/index.test.ts
@@ -209,3 +209,26 @@ test('should error when non-ignoreed values exceed the limit', async () => {
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toContain('Found 2 unique font sizes')
 })
+
+// ---------------------------------------------------------------------------
+// CSS keywords
+// ---------------------------------------------------------------------------
+
+test.each(['inherit', 'initial', 'unset', 'revert', 'revert-layer', 'auto'])(
+	'should not count %s as a unique font size',
+	async (keyword) => {
+		const { warnings, errored } = await lint(`a { font-size: ${keyword}; }`, 0)
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test('should count design token sizes while ignoring keywords mixed in', async () => {
+	const { warnings, errored } = await lint(
+		`a { font-size: 16px; } b { font-size: inherit; } c { font-size: 24px; }`,
+		1,
+	)
+	// inherit is a keyword and is not counted → 16px + 24px = 2 → exceeds limit of 1
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique font sizes')
+})

--- a/src/rules/max-unique-font-sizes/index.ts
+++ b/src/rules/max-unique-font-sizes/index.ts
@@ -1,7 +1,7 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
-import { destructureFontShorthand } from '@projectwallace/css-analyzer/values'
+import { destructureFontShorthand, keywords } from '@projectwallace/css-analyzer/values'
 import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
@@ -49,7 +49,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 
 		root.walkDecls('font-size', (declaration) => {
 			const before = unique_sizes.size
-			if (!isAllowed(declaration.value, ignore)) {
+			if (!keywords.has(declaration.value) && !isAllowed(declaration.value, ignore)) {
 				unique_sizes.add(declaration.value)
 			}
 			if (unique_sizes.size > before && unique_sizes.size > primaryOption) {

--- a/src/rules/max-unique-line-heights/index.test.ts
+++ b/src/rules/max-unique-line-heights/index.test.ts
@@ -204,3 +204,26 @@ test('should error when non-ignored values exceed the limit', async () => {
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toContain('Found 2 unique line heights')
 })
+
+// ---------------------------------------------------------------------------
+// CSS keywords
+// ---------------------------------------------------------------------------
+
+test.each(['inherit', 'initial', 'unset', 'revert', 'revert-layer'])(
+	'should not count %s as a unique line height',
+	async (keyword) => {
+		const { warnings, errored } = await lint(`a { line-height: ${keyword}; }`, 0)
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test('should count design token heights while ignoring keywords mixed in', async () => {
+	const { warnings, errored } = await lint(
+		`a { line-height: 1.5; } b { line-height: inherit; } c { line-height: 2; }`,
+		1,
+	)
+	// inherit is a keyword and is not counted → 1.5 + 2 = 2 → exceeds limit of 1
+	expect(errored).toBe(true)
+	expect(warnings[0].text).toContain('Found 2 unique line heights')
+})

--- a/src/rules/max-unique-line-heights/index.ts
+++ b/src/rules/max-unique-line-heights/index.ts
@@ -1,7 +1,7 @@
 import stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
-import { destructureFontShorthand } from '@projectwallace/css-analyzer/values'
+import { destructureFontShorthand, keywords } from '@projectwallace/css-analyzer/values'
 import { isAllowed, ignoreOptionValidators } from '../../utils/allow-list.js'
 
 const { createPlugin, utils } = stylelint
@@ -49,7 +49,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 
 		root.walkDecls('line-height', (declaration) => {
 			const before = unique_heights.size
-			if (!isAllowed(declaration.value, ignore)) {
+			if (!keywords.has(declaration.value) && !isAllowed(declaration.value, ignore)) {
 				unique_heights.add(declaration.value)
 			}
 			if (unique_heights.size > before && unique_heights.size > primaryOption) {


### PR DESCRIPTION
closes #130 