### PR TITLE
fix: dont count keyframes selectors for uniqueness

### DIFF
--- a/src/rules/max-average-selector-complexity/index.test.ts
+++ b/src/rules/max-average-selector-complexity/index.test.ts
@@ -66,3 +66,27 @@ test('should error when average selector complexity exceeds the limit', async ()
 	})
 	expect(warnings[0].text).toContain('greater than the allowed 1')
 })
+
+// ---------------------------------------------------------------------------
+// Keyframe selectors
+// ---------------------------------------------------------------------------
+
+test('should not count keyframe stops in the average', async () => {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: 1,
+		},
+	}
+
+	// `from`/`to` inside @keyframes are stops — must not skew the average
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `@keyframes fade { from { opacity: 0; } to { opacity: 1; } }`,
+		config,
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})

--- a/src/rules/max-average-selector-complexity/index.ts
+++ b/src/rules/max-average-selector-complexity/index.ts
@@ -3,6 +3,7 @@ import type { Root } from 'postcss'
 import { parse_selector_list } from '@projectwallace/css-parser/parse-selector'
 import { getComplexity } from '@projectwallace/css-analyzer/selectors'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
+import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -30,6 +31,7 @@ const ruleFunction = (primaryOption: number) => {
 		let selector_count = 0
 
 		root.walkRules((rule) => {
+			if (is_keyframe_rule(rule)) return
 			const parsed = parse_selector_list(rule.selector)
 
 			for (const selector of parsed) {

--- a/src/rules/max-average-selectors-per-rule/index.test.ts
+++ b/src/rules/max-average-selectors-per-rule/index.test.ts
@@ -66,3 +66,27 @@ test('should error when average selectors per rule exceeds the limit', async () 
 	})
 	expect(warnings[0].text).toContain('greater than the allowed 1')
 })
+
+// ---------------------------------------------------------------------------
+// Keyframe selectors
+// ---------------------------------------------------------------------------
+
+test('should not count keyframe stops in the average', async () => {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: 1,
+		},
+	}
+
+	// `from`/`to` inside @keyframes are stops — must not skew the average
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `@keyframes fade { from { opacity: 0; } to { opacity: 1; } }`,
+		config,
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})

--- a/src/rules/max-average-selectors-per-rule/index.ts
+++ b/src/rules/max-average-selectors-per-rule/index.ts
@@ -2,6 +2,7 @@ import stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_selector_list } from '@projectwallace/css-parser/parse-selector'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
+import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -29,6 +30,7 @@ const ruleFunction = (primaryOption: number) => {
 		let rule_count = 0
 
 		root.walkRules((rule) => {
+			if (is_keyframe_rule(rule)) return
 			const parsed = parse_selector_list(rule.selector)
 			total_selectors += parsed.child_count
 			rule_count++

--- a/src/rules/max-average-specificity/index.test.ts
+++ b/src/rules/max-average-specificity/index.test.ts
@@ -190,3 +190,27 @@ test('should allow float values in the primary option', async () => {
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
+
+// ---------------------------------------------------------------------------
+// Keyframe selectors
+// ---------------------------------------------------------------------------
+
+test('should not count keyframe stops in the average', async () => {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: [0, 0, 0],
+		},
+	}
+
+	// `from`/`100%` inside @keyframes are stops — must not skew the average
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `@keyframes fade { from { opacity: 0; } 100% { opacity: 1; } }`,
+		config,
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})

--- a/src/rules/max-average-specificity/index.ts
+++ b/src/rules/max-average-specificity/index.ts
@@ -2,6 +2,7 @@ import stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { getSpecificity, compareSpecificity } from '@projectwallace/css-analyzer/selectors'
 import type { Specificity } from '@projectwallace/css-analyzer'
+import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -37,6 +38,7 @@ const ruleFunction = (primaryOption: Specificity) => {
 		let selector_count = 0
 
 		root.walkRules((rule) => {
+			if (is_keyframe_rule(rule)) return
 			const specificities = getSpecificity(rule.selector)
 			for (const specificity of specificities) {
 				sum[0] += specificity[0]

--- a/src/rules/max-selector-complexity/index.test.ts
+++ b/src/rules/max-selector-complexity/index.test.ts
@@ -185,3 +185,27 @@ test('should only report the one selector in a list thats problematic', async ()
 		text: 'Selector complexity of "a a a a" is 7 which is greater than the allowed 2 (projectwallace/max-selector-complexity)',
 	})
 })
+
+// ---------------------------------------------------------------------------
+// Keyframe selectors
+// ---------------------------------------------------------------------------
+
+test('should not check keyframe stops', async () => {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: 2,
+		},
+	}
+
+	// `from`/`to` inside @keyframes are stops, not selectors — must not be analyzed
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `@keyframes fade { from { opacity: 0; } to { opacity: 1; } }`,
+		config,
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})

--- a/src/rules/max-selector-complexity/index.ts
+++ b/src/rules/max-selector-complexity/index.ts
@@ -2,6 +2,7 @@ import stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_selector_list } from '@projectwallace/css-parser/parse-selector'
 import { getComplexity } from '@projectwallace/css-analyzer/selectors'
+import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -28,6 +29,7 @@ const ruleFunction = (primaryOption: number) => {
 		}
 
 		root.walkRules((rule) => {
+			if (is_keyframe_rule(rule)) return
 			const selector_text = rule.selector
 			if (!selector_text.trim()) return
 

--- a/src/rules/max-selector-specificity/index.test.ts
+++ b/src/rules/max-selector-specificity/index.test.ts
@@ -254,3 +254,27 @@ test('should match issue example: [0, 2, 0] passes [0, 4, 0]', async () => {
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
+
+// ---------------------------------------------------------------------------
+// Keyframe selectors
+// ---------------------------------------------------------------------------
+
+test('should not check keyframe stops', async () => {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: [0, 0, 0],
+		},
+	}
+
+	// `from`/`to`/`100%` inside @keyframes are stops, not selectors — must not be analyzed
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `@keyframes fade { from { opacity: 0; } 100% { opacity: 1; } }`,
+		config,
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})

--- a/src/rules/max-selector-specificity/index.ts
+++ b/src/rules/max-selector-specificity/index.ts
@@ -2,6 +2,7 @@ import stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_selector_list } from '@projectwallace/css-parser/parse-selector'
 import { getSpecificity, compareSpecificity } from '@projectwallace/css-analyzer/selectors'
+import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -36,6 +37,7 @@ const ruleFunction = (primaryOption: Specificity) => {
 		if (!validOptions || !is_valid_specificity(primaryOption)) return
 
 		root.walkRules((rule) => {
+			if (is_keyframe_rule(rule)) return
 			const selector_text = rule.selector
 			if (!selector_text.trim()) return
 

--- a/src/rules/max-selectors-per-rule/index.test.ts
+++ b/src/rules/max-selectors-per-rule/index.test.ts
@@ -108,3 +108,27 @@ test('should report violation on the correct rule node', async () => {
 		'Selectors per rule is 11 which is greater than the allowed 10 (projectwallace/max-selectors-per-rule)',
 	)
 })
+
+// ---------------------------------------------------------------------------
+// Keyframe selectors
+// ---------------------------------------------------------------------------
+
+test('should not check keyframe stops', async () => {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: 1,
+		},
+	}
+
+	// `from` and `to` are keyframe stops, not real selectors — must not be analyzed
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `@keyframes fade { from { opacity: 0; } to { opacity: 1; } }`,
+		config,
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})

--- a/src/rules/max-selectors-per-rule/index.ts
+++ b/src/rules/max-selectors-per-rule/index.ts
@@ -2,6 +2,7 @@ import stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_selector_list } from '@projectwallace/css-parser/parse-selector'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
+import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -26,6 +27,7 @@ const ruleFunction = (primaryOption: number) => {
 		if (!validOptions) return
 
 		root.walkRules((rule) => {
+			if (is_keyframe_rule(rule)) return
 			const parsed = parse_selector_list(rule.selector)
 			const actual = parsed.child_count
 

--- a/src/rules/max-selectors/index.test.ts
+++ b/src/rules/max-selectors/index.test.ts
@@ -86,3 +86,16 @@ test('should error when count exceeds limit of 0', async () => {
 	expect(errored).toBe(true)
 	expect(warnings).toHaveLength(1)
 })
+
+// ---------------------------------------------------------------------------
+// Keyframe selectors
+// ---------------------------------------------------------------------------
+
+test('should not count keyframe stops as selectors', async () => {
+	const { warnings, errored } = await lint(
+		'@keyframes fade { from { opacity: 0; } to { opacity: 1; } }',
+		0,
+	)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})

--- a/src/rules/max-selectors/index.ts
+++ b/src/rules/max-selectors/index.ts
@@ -1,6 +1,7 @@
 import stylelint from 'stylelint'
 import type { Root, Rule } from 'postcss'
 import { is_valid_non_negative_integer } from '../../utils/option-validators.js'
+import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -26,6 +27,7 @@ const ruleFunction = (primaryOption: number) => {
 
 		let actual = 0
 		root.walkRules((rule: Rule) => {
+			if (is_keyframe_rule(rule)) return
 			actual += rule.selectors.length
 		})
 

--- a/src/rules/min-selector-uniqueness-ratio/index.test.ts
+++ b/src/rules/min-selector-uniqueness-ratio/index.test.ts
@@ -223,3 +223,23 @@ test('should not error when selectors inside nested atrules are all unique', asy
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
+
+test('should not count keyframe selectors', async () => {
+	const config = {
+		plugins: [plugin],
+		rules: {
+			[rule_name]: 1,
+		},
+	}
+
+	// Only `a` is a real selector; `from`/`to` are keyframe stops and must not be counted
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `a { color: red; } @keyframes fade { from { opacity: 0; } to { opacity: 1; } }`,
+		config,
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})

--- a/src/rules/min-selector-uniqueness-ratio/index.ts
+++ b/src/rules/min-selector-uniqueness-ratio/index.ts
@@ -1,6 +1,7 @@
 import stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_ratio } from '../../utils/option-validators.js'
+import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
 
 const { createPlugin, utils } = stylelint
 
@@ -28,6 +29,7 @@ const ruleFunction = (primaryOption: number) => {
 		let total_count = 0
 
 		root.walkRules((rule) => {
+			if (is_keyframe_rule(rule)) return
 			for (const selector of rule.selectors) {
 				unique_selectors.add(selector.trim())
 				total_count++

--- a/src/utils/is-keyframe-rule.ts
+++ b/src/utils/is-keyframe-rule.ts
@@ -1,0 +1,5 @@
+import type { Rule, AtRule } from 'postcss'
+
+export function is_keyframe_rule(rule: Rule): boolean {
+	return rule.parent?.type === 'atrule' && /keyframes/i.test((rule.parent as AtRule).name)
+}


### PR DESCRIPTION
## Problem

Eight selector-related rules used `root.walkRules()` without filtering out rules nested inside `@keyframes` blocks. PostCSS's `walkRules` visits **every** rule in the CSS tree, including keyframe stops like `from`, `to`, `0%`, and `100%`. These are not CSS selectors — they are animation timeline markers — so analyzing them as selectors produces incorrect results:

- `max-selectors` would count `from` and `to` as two selectors, inflating the total.
- `min-selector-uniqueness-ratio` would treat repeated `from`/`to` stops (across multiple animations) as duplicate selectors, lowering the uniqueness ratio unfairly.
- `max-selector-specificity` / `max-average-specificity` would try to compute the specificity of `100%`, which has no meaningful specificity.
- `max-selector-complexity` / `max-average-selector-complexity` would parse `from` as a selector and measure its complexity.
- `max-selectors-per-rule` / `max-average-selectors-per-rule` would include keyframe rules in their rule counts and averages.

## Fix

Added a shared utility `src/utils/is-keyframe-rule.ts`:

```ts
import type { Rule, AtRule } from 'postcss'

export function is_keyframe_rule(rule: Rule): boolean {
  return rule.parent?.type === 'atrule' && /keyframes/i.test((rule.parent as AtRule).name)
}
```

Each affected rule now calls `if (is_keyframe_rule(rule)) return` at the top of its `walkRules` callback. The regex covers both `@keyframes` and vendor-prefixed variants like `@-webkit-keyframes`.

## Affected rules

| Rule | Effect of bug |
|---|---|
| `min-selector-uniqueness-ratio` | Repeated keyframe stops counted as duplicate selectors |
| `max-selectors` | Keyframe stops inflated total selector count |
| `max-selectors-per-rule` | Keyframe rules included in per-rule selector analysis |
| `max-selector-complexity` | Keyframe stops parsed and measured as selectors |
| `max-selector-specificity` | Keyframe stops evaluated for specificity |
| `max-average-selector-complexity` | Keyframe stops skewed the complexity average |
| `max-average-selectors-per-rule` | Keyframe rules skewed the selectors-per-rule average |
| `max-average-specificity` | Keyframe stops skewed the specificity average |

## Tests

Each rule received a new test case verifying that CSS like the following does not trigger a violation regardless of how strict the configured limit is:

```css
@keyframes fade {
  from { opacity: 0; }
  to   { opacity: 1; }
}
```

closes #204 