### PR TITLE
Add no-pseudo-elements-in-is-where rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Rules that limit complexity and enforce conventions to keep CSS easy to reason a
 | [no-prefixed-values](src/rules/no-prefixed-values/README.md)                               | Disallow vendor-prefixed CSS values                                          |
 | [no-property-browserhacks](src/rules/no-property-browserhacks/README.md)                   | Prevent the use of known browserhacks for properties                         |
 | [no-property-shorthand](src/rules/no-property-shorthand/README.md)                         | Disallow the use of shorthand properties                                     |
+| [no-pseudo-elements-in-is-where](src/rules/no-pseudo-elements-in-is-where/README.md)       | Disallow pseudo-elements inside `:is()` and `:where()`                       |
 | [no-value-browserhacks](src/rules/no-value-browserhacks/README.md)                         | Disallow the use of known browser hacks in values                            |
 
 ## Holistic linting

--- a/src/configs/correctness.ts
+++ b/src/configs/correctness.ts
@@ -14,5 +14,6 @@ export default {
 		'projectwallace/no-unused-layers': true,
 		'projectwallace/no-static-media-queries': true,
 		'projectwallace/no-static-container-queries': true,
+		'projectwallace/no-pseudo-elements-in-is-where': true,
 	},
 }

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -20,6 +20,7 @@ export default {
 		'projectwallace/no-prefixed-values': true,
 		'projectwallace/no-property-browserhacks': true,
 		'projectwallace/no-property-shorthand': true,
+		'projectwallace/no-pseudo-elements-in-is-where': true,
 		'projectwallace/no-static-container-queries': true,
 		'projectwallace/no-static-media-queries': true,
 		'projectwallace/no-unknown-container-names': true,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -57,6 +57,7 @@ test('exports an array of stylelint rules', () => {
 		'projectwallace/no-prefixed-values',
 		'projectwallace/no-property-browserhacks',
 		'projectwallace/no-property-shorthand',
+		'projectwallace/no-pseudo-elements-in-is-where',
 		'projectwallace/no-static-container-queries',
 		'projectwallace/no-static-media-queries',
 		'projectwallace/no-unknown-container-names',

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import no_prefixed_atrules from './rules/no-prefixed-atrules/index.js'
 import no_prefixed_properties from './rules/no-prefixed-properties/index.js'
 import no_prefixed_selectors from './rules/no-prefixed-selectors/index.js'
 import no_prefixed_values from './rules/no-prefixed-values/index.js'
+import no_pseudo_elements_in_is_where from './rules/no-pseudo-elements-in-is-where/index.js'
 import no_property_browserhacks from './rules/no-property-browserhacks/index.js'
 import no_property_shorthand from './rules/no-property-shorthand/index.js'
 import no_value_browserhacks from './rules/no-value-browserhacks/index.js'
@@ -111,6 +112,7 @@ const plugins: stylelint.Plugin[] = [
 	no_prefixed_values,
 	no_property_browserhacks,
 	no_property_shorthand,
+	no_pseudo_elements_in_is_where,
 	no_static_container_queries,
 	no_static_media_queries,
 	no_unknown_container_names,

--- a/src/rules/no-pseudo-elements-in-is-where/README.md
+++ b/src/rules/no-pseudo-elements-in-is-where/README.md
@@ -1,0 +1,55 @@
+# No pseudo-elements in `:is()` and `:where()`
+
+Disallow pseudo-elements inside `:is()` and `:where()` selectors.
+
+<!-- prettier-ignore -->
+```css
+:is(::before, ::after) { content: "" }
+/*   ↑
+*    Pseudo-elements are not valid inside :is() or :where() */
+```
+
+Pseudo-elements like `::before` and `::after` are not valid in `:is()` or `:where()`. According to the CSS spec, these functions only accept a [forgiving selector list](https://www.w3.org/TR/selectors-4/#typedef-forgiving-selector-list), which does not include pseudo-elements. While browsers may silently ignore invalid entries in `:is()` due to its forgiving nature, this means the rule will have no effect — which is likely not what was intended.
+
+## Options
+
+`true`
+
+The following are considered violations:
+
+<!-- prettier-ignore -->
+```css
+:is(::before, ::after) {
+	content: "";
+}
+```
+
+<!-- prettier-ignore -->
+```css
+:where(::placeholder) {
+	color: grey;
+}
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+:is(a, button) {
+	color: red;
+}
+```
+
+<!-- prettier-ignore -->
+```css
+:where(:hover, :focus) {
+	outline: none;
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a::before {
+	content: "";
+}
+```

--- a/src/rules/no-pseudo-elements-in-is-where/index.test.ts
+++ b/src/rules/no-pseudo-elements-in-is-where/index.test.ts
@@ -1,0 +1,97 @@
+import stylelint from 'stylelint'
+import { test, expect } from 'vitest'
+import plugin from './index.js'
+
+const rule_name = 'projectwallace/no-pseudo-elements-in-is-where'
+
+async function lint(code: string, primaryOption: unknown) {
+	const {
+		results: [result],
+	} = await stylelint.lint({
+		code,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[rule_name]: primaryOption,
+			},
+		},
+	})
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Invalid options
+// ---------------------------------------------------------------------------
+
+test('should not run when option is invalid', async () => {
+	const { errored } = await lint('a { color: red }', false)
+	expect(errored).toBe(true)
+})
+
+// ---------------------------------------------------------------------------
+// No violation
+// ---------------------------------------------------------------------------
+
+test('should not error for normal rules', async () => {
+	const { warnings, errored } = await lint('a { color: red }', true)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not error for pseudo-class inside :is()', async () => {
+	const { warnings, errored } = await lint(':is(:hover, :focus) { color: red }', true)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not error for pseudo-class inside :where()', async () => {
+	const { warnings, errored } = await lint(':where(:hover, :focus) { color: red }', true)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not error for type selectors inside :is()', async () => {
+	const { warnings, errored } = await lint(':is(a, button) { color: red }', true)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should not error for pseudo-elements outside :is() or :where()', async () => {
+	const { warnings, errored } = await lint('a::before { content: "" }', true)
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+// ---------------------------------------------------------------------------
+// Violation
+// ---------------------------------------------------------------------------
+
+test('should error for ::before inside :is()', async () => {
+	const { warnings, errored } = await lint(':is(::before, ::after) { content: "" }', true)
+	expect(errored).toBe(true)
+	expect(warnings).toHaveLength(2)
+})
+
+test('should error for ::before inside :where()', async () => {
+	const { warnings, errored } = await lint(':where(::before) { content: "" }', true)
+	expect(errored).toBe(true)
+	expect(warnings).toHaveLength(1)
+})
+
+test('should error for ::after inside :is()', async () => {
+	const { warnings, errored } = await lint(':is(::after) { content: "" }', true)
+	expect(errored).toBe(true)
+	expect(warnings).toHaveLength(1)
+})
+
+test('should error for pseudo-element mixed with valid selectors inside :is()', async () => {
+	const { warnings, errored } = await lint(':is(a, ::before) { color: red }', true)
+	expect(errored).toBe(true)
+	expect(warnings).toHaveLength(1)
+})
+
+test('should error for ::placeholder inside :is()', async () => {
+	const { warnings, errored } = await lint(':is(::placeholder) { color: red }', true)
+	expect(errored).toBe(true)
+	expect(warnings).toHaveLength(1)
+})

--- a/src/rules/no-pseudo-elements-in-is-where/index.ts
+++ b/src/rules/no-pseudo-elements-in-is-where/index.ts
@@ -1,0 +1,68 @@
+import stylelint from 'stylelint'
+import type { Root } from 'postcss'
+import {
+	walk,
+	SKIP,
+	parse_selector_list,
+	is_pseudo_class_selector,
+	is_pseudo_element_selector,
+} from '@projectwallace/css-parser'
+
+const { createPlugin, utils } = stylelint
+const rule_name = 'projectwallace/no-pseudo-elements-in-is-where'
+
+const messages = utils.ruleMessages(rule_name, {
+	rejected: (pseudo_element: string, pseudo_function: string) =>
+		`Pseudo-element "${pseudo_element}" is not allowed inside ":${pseudo_function}()"`,
+})
+
+const meta = {
+	url: 'https://github.com/projectwallace/stylelint-plugin/blob/main/src/rules/no-pseudo-elements-in-is-where/README.md',
+}
+
+const ruleFunction = (primaryOption: true) => {
+	return (root: Root, result: stylelint.PostcssResult) => {
+		const validOptions = utils.validateOptions(result, rule_name, {
+			actual: primaryOption,
+			possible: [true],
+		})
+
+		if (!validOptions) return
+
+		root.walkRules((rule) => {
+			const selector_text = rule.selector
+			if (!selector_text.trim()) return
+
+			const selector_list = parse_selector_list(selector_text)
+
+			walk(selector_list, (node) => {
+				if (!is_pseudo_class_selector(node)) return
+
+				const name = node.name.toLowerCase()
+				if (name !== 'is' && name !== 'where') return SKIP
+
+				// We're inside :is() or :where() - check for pseudo-elements
+				walk(node, (child) => {
+					if (child === node) return
+					if (is_pseudo_element_selector(child)) {
+						utils.report({
+							message: messages.rejected(`::${child.name}`, name),
+							node: rule,
+							result,
+							ruleName: rule_name,
+							word: `::${child.name}`,
+						})
+					}
+				})
+
+				return SKIP
+			})
+		})
+	}
+}
+
+ruleFunction.ruleName = rule_name
+ruleFunction.messages = messages
+ruleFunction.meta = meta
+
+export default createPlugin(rule_name, ruleFunction)


### PR DESCRIPTION
## Summary
This PR adds a new stylelint rule that disallows pseudo-elements inside `:is()` and `:where()` selectors, which are invalid according to the CSS specification.

## Key Changes
- **New rule implementation** (`src/rules/no-pseudo-elements-in-is-where/index.ts`): Detects and reports pseudo-elements (e.g., `::before`, `::after`, `::placeholder`) used inside `:is()` or `:where()` functions
- **Comprehensive test suite** (`src/rules/no-pseudo-elements-in-is-where/index.test.ts`): 10 test cases covering valid selectors, invalid pseudo-elements, and edge cases
- **Documentation** (`src/rules/no-pseudo-elements-in-is-where/README.md`): Explains the rule, rationale, and provides examples of violations and valid patterns
- **Plugin integration**: Added the new rule to both `correctness` and `recommended` configurations
- **Export updates**: Updated main plugin exports and test suite to include the new rule

## Implementation Details
- Uses the `@projectwallace/css-parser` utilities to parse and walk the selector tree
- Validates that the rule option is `true` before running
- Reports violations with clear messages indicating which pseudo-element and which function (`:is()` or `:where()`) caused the issue
- Properly skips nested traversal after finding `:is()` or `:where()` to avoid false positives

closes #210 