### PR TITLE
Allow single-value shorthands in recommended config

### DIFF
--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -19,7 +19,10 @@ export default {
 		],
 		'projectwallace/no-prefixed-values': true,
 		'projectwallace/no-property-browserhacks': true,
-		'projectwallace/no-property-shorthand': true,
+		'projectwallace/no-property-shorthand': [
+			true,
+			{ ignore: 'single-value' }
+		],
 		'projectwallace/no-pseudo-elements-in-is-where': true,
 		'projectwallace/no-static-container-queries': true,
 		'projectwallace/no-static-media-queries': true,


### PR DESCRIPTION
Not allowing shorthand at all is a little too strict.