### PR TITLE
make `max-unique-*` messages less verbose: do not show all unique items

### DIFF
--- a/src/rules/max-unique-animation-functions/index.ts
+++ b/src/rules/max-unique-animation-functions/index.ts
@@ -14,8 +14,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-animation-functions'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, shadows: string[]) =>
-		`Found ${actual} unique animation-functions (${shadows.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique animation-functions which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -85,7 +85,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_functions.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_functions]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-box-shadows/index.test.ts
+++ b/src/rules/max-unique-box-shadows/index.test.ts
@@ -91,7 +91,7 @@ test('should error when unique box-shadows exceed the limit', async () => {
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0]).toMatchObject({ rule: rule_name, severity: 'error' })
 	expect(warnings[0].text).toBe(
-		'Found 3 unique box shadows (0 2px 4px red, 0 4px 8px blue, 0 8px 16px green) which exceeds the maximum of 2 (projectwallace/max-unique-box-shadows)',
+		'Found 3 unique box shadows which exceeds the maximum of 2 (projectwallace/max-unique-box-shadows)',
 	)
 	expect(warnings[0].line).toBe(4)
 })
@@ -156,7 +156,7 @@ test('should treat different shadow values as different unique shadows', async (
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique box shadows (0 2px 4px red, 0 4px 8px red) which exceeds the maximum of 1 (projectwallace/max-unique-box-shadows)',
+		'Found 2 unique box shadows which exceeds the maximum of 1 (projectwallace/max-unique-box-shadows)',
 	)
 	expect(warnings[0].line).toBe(3)
 })
@@ -172,7 +172,7 @@ test('should count unique box-shadows across the entire stylesheet', async () =>
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 3 unique box shadows (0 2px 4px red, 0 4px 8px blue, 0 8px 16px green) which exceeds the maximum of 2 (projectwallace/max-unique-box-shadows)',
+		'Found 3 unique box shadows which exceeds the maximum of 2 (projectwallace/max-unique-box-shadows)',
 	)
 	expect(warnings[0].line).toBe(4)
 })
@@ -236,6 +236,6 @@ test('should count design token shadows while ignoring keywords mixed in', async
 	// none is a keyword and is not counted → 2 unique shadows → exceeds limit of 1
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique box shadows (0 2px 4px red, 0 4px 8px blue) which exceeds the maximum of 1 (projectwallace/max-unique-box-shadows)',
+		'Found 2 unique box shadows which exceeds the maximum of 1 (projectwallace/max-unique-box-shadows)',
 	)
 })

--- a/src/rules/max-unique-box-shadows/index.ts
+++ b/src/rules/max-unique-box-shadows/index.ts
@@ -12,8 +12,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-box-shadows'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, shadows: string[]) =>
-		`Found ${actual} unique box shadows (${shadows.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique box shadows which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -64,7 +64,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_shadows.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_shadows]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-color-formats/index.test.ts
+++ b/src/rules/max-unique-color-formats/index.test.ts
@@ -110,7 +110,7 @@ test('should error with the correct message', async () => {
 	const { warnings, errored } = await lint(`a { color: red; background-color: #00f; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique color formats (named, hex) which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
+		'Found 2 unique color formats which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
 	)
 })
 
@@ -165,7 +165,7 @@ test('should count rgb and rgba as different formats', async () => {
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique color formats (rgb, rgba) which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
+		'Found 2 unique color formats which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
 	)
 })
 
@@ -176,7 +176,7 @@ test('should count hsl and hsla as different formats', async () => {
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique color formats (hsl, hsla) which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
+		'Found 2 unique color formats which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
 	)
 })
 
@@ -229,7 +229,7 @@ test('should detect mixed formats inside color-mix', async () => {
 	// red → named, #000 → hex = 2 unique formats
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique color formats (named, hex) which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
+		'Found 2 unique color formats which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
 	)
 })
 
@@ -238,7 +238,7 @@ test('should detect mixed formats inside light-dark', async () => {
 	// white → named, #000 → hex = 2 unique formats
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique color formats (named, hex) which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
+		'Found 2 unique color formats which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
 	)
 })
 
@@ -280,7 +280,7 @@ test('should count format from @property initial-value', async () => {
 	const { warnings, errored } = await lint(code, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique color formats (hex, oklch) which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
+		'Found 2 unique color formats which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
 	)
 })
 
@@ -298,7 +298,7 @@ test('should detect format in box-shadow', async () => {
 	const { warnings, errored } = await lint(`a { box-shadow: 0 0 10px red, 0 0 20px #00f; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique color formats (named, hex) which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
+		'Found 2 unique color formats which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
 	)
 })
 
@@ -306,7 +306,7 @@ test('should detect formats inside gradient functions', async () => {
 	const { warnings, errored } = await lint(`a { background-image: linear-gradient(red, #00f); }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique color formats (named, hex) which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
+		'Found 2 unique color formats which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
 	)
 })
 
@@ -314,7 +314,7 @@ test('should detect formats in custom properties', async () => {
 	const { warnings, errored } = await lint(`a { --text: red; --bg: #000; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique color formats (named, hex) which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
+		'Found 2 unique color formats which exceeds the maximum of 1 (projectwallace/max-unique-color-formats)',
 	)
 })
 

--- a/src/rules/max-unique-color-formats/index.ts
+++ b/src/rules/max-unique-color-formats/index.ts
@@ -9,8 +9,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-color-formats'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, formats: string[]) =>
-		`Found ${actual} unique color formats (${formats.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique color formats which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -65,7 +65,7 @@ const ruleFunction = (primaryOption: number) => {
 		const actual = unique_formats.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_formats]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-colors/index.test.ts
+++ b/src/rules/max-unique-colors/index.test.ts
@@ -84,7 +84,7 @@ test('should error when unique colors exceed the limit', async () => {
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0]).toMatchObject({ rule: rule_name, severity: 'error' })
 	expect(warnings[0].text).toBe(
-		'Found 3 unique colors (red, blue, green) which exceeds the maximum of 2 (projectwallace/max-unique-colors)',
+		'Found 3 unique colors which exceeds the maximum of 2 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -110,7 +110,7 @@ test('should recognise named colors case-insensitively as colors', async () => {
 	// Red ≠ RED → 2 unique colors → violation
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (Red, RED) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -124,7 +124,7 @@ test('should recognise transparent as a color', async () => {
 	const { warnings, errored } = await lint(`a { background-color: transparent; color: red; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (transparent, red) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -132,7 +132,7 @@ test('should recognise currentColor as a color', async () => {
 	const { warnings, errored } = await lint(`a { border-color: currentColor; color: red; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (currentColor, red) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -169,7 +169,7 @@ test('should treat different hex strings as different unique colors', async () =
 	const { warnings, errored } = await lint(`a { color: #f00; background-color: #ff0000; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (#f00, #ff0000) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -178,7 +178,7 @@ test('should preserve hex casing for uniqueness', async () => {
 	const { warnings, errored } = await lint(`a { color: #FFF; } b { color: #fff; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (#FFF, #fff) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -280,7 +280,7 @@ test('should detect colors in box-shadow', async () => {
 	const { warnings, errored } = await lint(`a { box-shadow: 0 0 10px red, 0 0 20px blue; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (red, blue) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -294,7 +294,7 @@ test('should detect named colors inside linear-gradient()', async () => {
 	const { warnings, errored } = await lint(`a { background-image: linear-gradient(red, blue); }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (red, blue) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -305,7 +305,7 @@ test('should detect hex colors inside radial-gradient()', async () => {
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (#fff, #000) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -352,7 +352,7 @@ test('should count multiple fallback colors from different var() declarations', 
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (red, blue) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -406,7 +406,7 @@ test('should count initial-value AND usages together', async () => {
 	const { warnings, errored } = await lint(code, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (red, blue) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -436,7 +436,7 @@ test('should count initial-value with hex color', async () => {
 	const { warnings, errored } = await lint(code, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (#ff0000, blue) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -475,7 +475,7 @@ test('should count var() as a unique color when it is a @property <color>', asyn
 	const { warnings, errored } = await lint(code, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 4 unique colors (red, blue, var(--brand-color), var(--accent-color)) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 4 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -493,7 +493,7 @@ test('should count the var() expression AND fallback colors separately', async (
 	const { warnings, errored } = await lint(code, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 3 unique colors (blue, var(--brand-color, red), red) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 3 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -594,7 +594,7 @@ test('should detect colors declared in custom properties', async () => {
 	const { warnings, errored } = await lint(`a { --text-color: red; --bg-color: blue; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique colors (red, blue) which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
+		'Found 2 unique colors which exceeds the maximum of 1 (projectwallace/max-unique-colors)',
 	)
 })
 
@@ -609,7 +609,7 @@ test('should count unique colors across the entire stylesheet', async () => {
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 3 unique colors (red, blue, green) which exceeds the maximum of 2 (projectwallace/max-unique-colors)',
+		'Found 3 unique colors which exceeds the maximum of 2 (projectwallace/max-unique-colors)',
 	)
 })
 

--- a/src/rules/max-unique-colors/index.ts
+++ b/src/rules/max-unique-colors/index.ts
@@ -13,8 +13,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-colors'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, colors: string[]) =>
-		`Found ${actual} unique colors (${colors.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique colors which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -94,7 +94,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_colors.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_colors]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-durations/index.test.ts
+++ b/src/rules/max-unique-durations/index.test.ts
@@ -85,7 +85,7 @@ test('should error when unique durations exceed the limit', async () => {
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0]).toMatchObject({ rule: rule_name, severity: 'error' })
 	expect(warnings[0].text).toBe(
-		'Found 3 unique durations (1s, 2s, 3s) which exceeds the maximum of 2 (projectwallace/max-unique-durations)',
+		'Found 3 unique durations which exceeds the maximum of 2 (projectwallace/max-unique-durations)',
 	)
 	expect(warnings[0].line).toBe(4)
 })
@@ -116,7 +116,7 @@ test('should count comma-separated animation-duration values as separate duratio
 	const { warnings, errored } = await lint(`a { animation-duration: 1s, 2s; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique durations (1s, 2s) which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
+		'Found 2 unique durations which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
 	)
 })
 
@@ -140,7 +140,7 @@ test('should count comma-separated transition-duration values as separate durati
 	const { warnings, errored } = await lint(`a { transition-duration: 100ms, 200ms; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique durations (100ms, 200ms) which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
+		'Found 2 unique durations which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
 	)
 })
 
@@ -164,7 +164,7 @@ test('should error when animation shorthand introduces a new unique duration', a
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique durations (1s, 2s) which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
+		'Found 2 unique durations which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
 	)
 })
 
@@ -188,7 +188,7 @@ test('should error when transition shorthand introduces a new unique duration', 
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique durations (100ms, 300ms) which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
+		'Found 2 unique durations which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
 	)
 })
 
@@ -206,7 +206,7 @@ test('should count durations across animation-duration and transition-duration',
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique durations (1s, 2s) which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
+		'Found 2 unique durations which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
 	)
 })
 
@@ -268,6 +268,6 @@ test('should count design token durations while ignoring keywords mixed in', asy
 	// inherit is a keyword and is not counted → 1s + 2s = 2 → exceeds limit of 1
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique durations (1s, 2s) which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
+		'Found 2 unique durations which exceeds the maximum of 1 (projectwallace/max-unique-durations)',
 	)
 })

--- a/src/rules/max-unique-durations/index.ts
+++ b/src/rules/max-unique-durations/index.ts
@@ -14,8 +14,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-durations'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, shadows: string[]) =>
-		`Found ${actual} unique durations (${shadows.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique durations which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -83,7 +83,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_durations.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_durations]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-font-families/index.test.ts
+++ b/src/rules/max-unique-font-families/index.test.ts
@@ -34,7 +34,7 @@ test('should error when 0 is configured and any font-family is used', async () =
 	expect(errored).toBe(true)
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0].text).toBe(
-		'Found 1 unique font families (Arial) which exceeds the maximum of 0 (projectwallace/max-unique-font-families)',
+		'Found 1 unique font families which exceeds the maximum of 0 (projectwallace/max-unique-font-families)',
 	)
 })
 
@@ -102,7 +102,7 @@ test('should error when unique values exceed the limit', async () => {
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0]).toMatchObject({ rule: rule_name, severity: 'error' })
 	expect(warnings[0].text).toBe(
-		'Found 3 unique font families (Arial, Georgia, monospace) which exceeds the maximum of 2 (projectwallace/max-unique-font-families)',
+		'Found 3 unique font families which exceeds the maximum of 2 (projectwallace/max-unique-font-families)',
 	)
 })
 
@@ -126,7 +126,7 @@ test('should treat different value strings as different unique entries', async (
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique font families (Arial, sans-serif, Arial) which exceeds the maximum of 1 (projectwallace/max-unique-font-families)',
+		'Found 2 unique font families which exceeds the maximum of 1 (projectwallace/max-unique-font-families)',
 	)
 })
 
@@ -150,7 +150,7 @@ test('should count families from font shorthand and font-family together', async
 	const { warnings, errored } = await lint(`a { font-family: Arial; } b { font: 16px Georgia; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique font families (Arial, Georgia) which exceeds the maximum of 1 (projectwallace/max-unique-font-families)',
+		'Found 2 unique font families which exceeds the maximum of 1 (projectwallace/max-unique-font-families)',
 	)
 })
 
@@ -252,7 +252,7 @@ test('should not count font-family inside @font-face but still count outside', a
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique font families (Arial, Georgia) which exceeds the maximum of 1 (projectwallace/max-unique-font-families)',
+		'Found 2 unique font families which exceeds the maximum of 1 (projectwallace/max-unique-font-families)',
 	)
 })
 
@@ -269,7 +269,7 @@ test('should error when non-ignoreed values exceed the limit', async () => {
 	// Arial ignored → Georgia + monospace = 2 → exceeds limit of 1
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique font families (Georgia, monospace) which exceeds the maximum of 1 (projectwallace/max-unique-font-families)',
+		'Found 2 unique font families which exceeds the maximum of 1 (projectwallace/max-unique-font-families)',
 	)
 })
 
@@ -294,6 +294,6 @@ test('should count design token families while ignoring keywords mixed in', asyn
 	// inherit is a keyword and is not counted → Arial + Georgia = 2 → exceeds limit of 1
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique font families (Arial, Georgia) which exceeds the maximum of 1 (projectwallace/max-unique-font-families)',
+		'Found 2 unique font families which exceeds the maximum of 1 (projectwallace/max-unique-font-families)',
 	)
 })

--- a/src/rules/max-unique-font-families/index.ts
+++ b/src/rules/max-unique-font-families/index.ts
@@ -13,8 +13,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-font-families'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, families: string[]) =>
-		`Found ${actual} unique font families (${families.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique font families which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -80,7 +80,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_families.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_families]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-font-sizes/index.test.ts
+++ b/src/rules/max-unique-font-sizes/index.test.ts
@@ -34,7 +34,7 @@ test('should error when 0 is configured and any font-size is used', async () => 
 	expect(errored).toBe(true)
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0].text).toBe(
-		'Found 1 unique font sizes (16px) which exceeds the maximum of 0 (projectwallace/max-unique-font-sizes)',
+		'Found 1 unique font sizes which exceeds the maximum of 0 (projectwallace/max-unique-font-sizes)',
 	)
 })
 
@@ -90,7 +90,7 @@ test('should error when unique values exceed the limit', async () => {
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0]).toMatchObject({ rule: rule_name, severity: 'error' })
 	expect(warnings[0].text).toBe(
-		'Found 3 unique font sizes (12px, 16px, 24px) which exceeds the maximum of 2 (projectwallace/max-unique-font-sizes)',
+		'Found 3 unique font sizes which exceeds the maximum of 2 (projectwallace/max-unique-font-sizes)',
 	)
 })
 
@@ -111,7 +111,7 @@ test('should treat different value strings as different unique entries', async (
 	const { warnings, errored } = await lint(`a { font-size: 1rem; } b { font-size: 16px; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique font sizes (1rem, 16px) which exceeds the maximum of 1 (projectwallace/max-unique-font-sizes)',
+		'Found 2 unique font sizes which exceeds the maximum of 1 (projectwallace/max-unique-font-sizes)',
 	)
 })
 
@@ -135,7 +135,7 @@ test('should count sizes from font shorthand and font-size together', async () =
 	const { warnings, errored } = await lint(`a { font-size: 16px; } b { font: 24px Georgia; }`, 1)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique font sizes (16px, 24px) which exceeds the maximum of 1 (projectwallace/max-unique-font-sizes)',
+		'Found 2 unique font sizes which exceeds the maximum of 1 (projectwallace/max-unique-font-sizes)',
 	)
 })
 
@@ -212,7 +212,7 @@ test('should error when non-ignoreed values exceed the limit', async () => {
 	// 12px ignored → 16px + 24px = 2 → exceeds limit of 1
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique font sizes (16px, 24px) which exceeds the maximum of 1 (projectwallace/max-unique-font-sizes)',
+		'Found 2 unique font sizes which exceeds the maximum of 1 (projectwallace/max-unique-font-sizes)',
 	)
 })
 
@@ -237,6 +237,6 @@ test('should count design token sizes while ignoring keywords mixed in', async (
 	// inherit is a keyword and is not counted → 16px + 24px = 2 → exceeds limit of 1
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique font sizes (16px, 24px) which exceeds the maximum of 1 (projectwallace/max-unique-font-sizes)',
+		'Found 2 unique font sizes which exceeds the maximum of 1 (projectwallace/max-unique-font-sizes)',
 	)
 })

--- a/src/rules/max-unique-font-sizes/index.ts
+++ b/src/rules/max-unique-font-sizes/index.ts
@@ -13,8 +13,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-font-sizes'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, sizes: string[]) =>
-		`Found ${actual} unique font sizes (${sizes.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique font sizes which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -74,7 +74,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_sizes.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_sizes]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-gradients/index.ts
+++ b/src/rules/max-unique-gradients/index.ts
@@ -14,8 +14,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-gradients'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, gradients: string[]) =>
-		`Found ${actual} unique gradients (${gradients.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique gradients which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -73,7 +73,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_gradients.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_gradients]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-keyframes/index.ts
+++ b/src/rules/max-unique-keyframes/index.ts
@@ -11,8 +11,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-keyframes'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, names: string[]) =>
-		`Found ${actual} unique keyframes (${names.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique keyframes which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -60,7 +60,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_keyframes.size
 		for (const atRule of violating_at_rules) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_keyframes]),
+				message: messages.rejected(actual, primaryOption),
 				node: atRule,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-line-heights/index.ts
+++ b/src/rules/max-unique-line-heights/index.ts
@@ -13,8 +13,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-line-heights'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, heights: string[]) =>
-		`Found ${actual} unique line heights (${heights.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique line heights which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -74,7 +74,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_heights.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_heights]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-media-queries/index.test.ts
+++ b/src/rules/max-unique-media-queries/index.test.ts
@@ -34,7 +34,7 @@ test('should error when 0 is configured and any media query is used', async () =
 	expect(errored).toBe(true)
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0].text).toBe(
-		'Found 1 unique media queries ((max-width: 768px)) which exceeds the maximum of 0 (projectwallace/max-unique-media-queries)',
+		'Found 1 unique media queries which exceeds the maximum of 0 (projectwallace/max-unique-media-queries)',
 	)
 })
 
@@ -96,7 +96,7 @@ test('should error when unique queries exceed the limit', async () => {
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0]).toMatchObject({ rule: rule_name, severity: 'error' })
 	expect(warnings[0].text).toBe(
-		'Found 3 unique media queries ((max-width: 768px), (min-width: 1024px), (min-width: 1440px)) which exceeds the maximum of 2 (projectwallace/max-unique-media-queries)',
+		'Found 3 unique media queries which exceeds the maximum of 2 (projectwallace/max-unique-media-queries)',
 	)
 })
 
@@ -119,7 +119,7 @@ test('should treat different query strings as different unique entries', async (
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique media queries ((max-width: 768px), screen and (max-width: 768px)) which exceeds the maximum of 1 (projectwallace/max-unique-media-queries)',
+		'Found 2 unique media queries which exceeds the maximum of 1 (projectwallace/max-unique-media-queries)',
 	)
 })
 
@@ -155,6 +155,6 @@ test('should error when non-ignored values exceed the limit', async () => {
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique media queries ((min-width: 1024px), (min-width: 1440px)) which exceeds the maximum of 1 (projectwallace/max-unique-media-queries)',
+		'Found 2 unique media queries which exceeds the maximum of 1 (projectwallace/max-unique-media-queries)',
 	)
 })

--- a/src/rules/max-unique-media-queries/index.ts
+++ b/src/rules/max-unique-media-queries/index.ts
@@ -11,8 +11,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-media-queries'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, queries: string[]) =>
-		`Found ${actual} unique media queries (${queries.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique media queries which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -60,7 +60,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_queries.size
 		for (const atRule of violating_at_rules) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_queries]),
+				message: messages.rejected(actual, primaryOption),
 				node: atRule,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-supports-queries/index.test.ts
+++ b/src/rules/max-unique-supports-queries/index.test.ts
@@ -34,7 +34,7 @@ test('should error when 0 is configured and any supports query is used', async (
 	expect(errored).toBe(true)
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0].text).toBe(
-		'Found 1 unique supports queries ((display: grid)) which exceeds the maximum of 0 (projectwallace/max-unique-supports-queries)',
+		'Found 1 unique supports queries which exceeds the maximum of 0 (projectwallace/max-unique-supports-queries)',
 	)
 })
 
@@ -96,7 +96,7 @@ test('should error when unique queries exceed the limit', async () => {
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0]).toMatchObject({ rule: rule_name, severity: 'error' })
 	expect(warnings[0].text).toBe(
-		'Found 3 unique supports queries ((display: grid), (display: flex), (display: contents)) which exceeds the maximum of 2 (projectwallace/max-unique-supports-queries)',
+		'Found 3 unique supports queries which exceeds the maximum of 2 (projectwallace/max-unique-supports-queries)',
 	)
 })
 
@@ -119,7 +119,7 @@ test('should treat different query strings as different unique entries', async (
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique supports queries ((display: grid), not (display: grid)) which exceeds the maximum of 1 (projectwallace/max-unique-supports-queries)',
+		'Found 2 unique supports queries which exceeds the maximum of 1 (projectwallace/max-unique-supports-queries)',
 	)
 })
 
@@ -155,6 +155,6 @@ test('should error when non-ignored values exceed the limit', async () => {
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique supports queries ((display: flex), (display: contents)) which exceeds the maximum of 1 (projectwallace/max-unique-supports-queries)',
+		'Found 2 unique supports queries which exceeds the maximum of 1 (projectwallace/max-unique-supports-queries)',
 	)
 })

--- a/src/rules/max-unique-supports-queries/index.ts
+++ b/src/rules/max-unique-supports-queries/index.ts
@@ -11,8 +11,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-supports-queries'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, queries: string[]) =>
-		`Found ${actual} unique supports queries (${queries.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique supports queries which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -60,7 +60,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_queries.size
 		for (const at_rule of violating_at_rules) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_queries]),
+				message: messages.rejected(actual, primaryOption),
 				node: at_rule,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-text-shadows/index.test.ts
+++ b/src/rules/max-unique-text-shadows/index.test.ts
@@ -91,7 +91,7 @@ test('should error when unique text-shadows exceed the limit', async () => {
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0]).toMatchObject({ rule: rule_name, severity: 'error' })
 	expect(warnings[0].text).toBe(
-		'Found 3 unique text shadows (1px 1px red, 2px 2px blue, 3px 3px green) which exceeds the maximum of 2 (projectwallace/max-unique-text-shadows)',
+		'Found 3 unique text shadows which exceeds the maximum of 2 (projectwallace/max-unique-text-shadows)',
 	)
 	expect(warnings[0].line).toBe(4)
 })
@@ -144,7 +144,7 @@ test('should treat different shadow values as different unique shadows', async (
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique text shadows (1px 1px red, 2px 2px red) which exceeds the maximum of 1 (projectwallace/max-unique-text-shadows)',
+		'Found 2 unique text shadows which exceeds the maximum of 1 (projectwallace/max-unique-text-shadows)',
 	)
 	expect(warnings[0].line).toBe(3)
 })
@@ -160,7 +160,7 @@ test('should count unique text-shadows across the entire stylesheet', async () =
 	)
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 3 unique text shadows (1px 1px red, 2px 2px blue, 3px 3px green) which exceeds the maximum of 2 (projectwallace/max-unique-text-shadows)',
+		'Found 3 unique text shadows which exceeds the maximum of 2 (projectwallace/max-unique-text-shadows)',
 	)
 	expect(warnings[0].line).toBe(4)
 })
@@ -224,6 +224,6 @@ test('should count design token shadows while ignoring keywords mixed in', async
 	// none is a keyword and is not counted → 2 unique shadows → exceeds limit of 1
 	expect(errored).toBe(true)
 	expect(warnings[0].text).toBe(
-		'Found 2 unique text shadows (1px 1px red, 2px 2px blue) which exceeds the maximum of 1 (projectwallace/max-unique-text-shadows)',
+		'Found 2 unique text shadows which exceeds the maximum of 1 (projectwallace/max-unique-text-shadows)',
 	)
 })

--- a/src/rules/max-unique-text-shadows/index.ts
+++ b/src/rules/max-unique-text-shadows/index.ts
@@ -12,8 +12,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-text-shadows'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, shadows: string[]) =>
-		`Found ${actual} unique text shadows (${shadows.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique text shadows which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -64,7 +64,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_shadows.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_shadows]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-units/index.test.ts
+++ b/src/rules/max-unique-units/index.test.ts
@@ -100,9 +100,7 @@ test('should error when unique units exceed the limit', async () => {
 		rule: rule_name,
 		severity: 'error',
 	})
-	expect(warnings[0].text).toContain(
-		'Found 3 unique CSS units (px, vw, rem) which is greater than the allowed 2',
-	)
+	expect(warnings[0].text).toContain('Found 3 unique CSS units which is greater than the allowed 2')
 })
 
 test('should treat units case-insensitively', async () => {

--- a/src/rules/max-unique-units/index.ts
+++ b/src/rules/max-unique-units/index.ts
@@ -9,8 +9,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-units'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, units: string[]) =>
-		`Found ${actual} unique CSS units (${units.join(', ')}) which is greater than the allowed ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique CSS units which is greater than the allowed ${expected}`,
 })
 
 const meta = {
@@ -50,7 +50,7 @@ const ruleFunction = (primaryOption: number) => {
 		const actual = unique_units.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_units]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,

--- a/src/rules/max-unique-z-indexes/index.test.ts
+++ b/src/rules/max-unique-z-indexes/index.test.ts
@@ -85,7 +85,7 @@ test('should error when unique z-indexes exceed the limit', async () => {
 	const { warnings } = await lint(`a { z-index: 1; } b { z-index: 2; }`, 1)
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0].text).toBe(
-		`Found 2 unique z-indexes (1, 2) which exceeds the maximum of 1 (projectwallace/max-unique-z-indexes)`,
+		`Found 2 unique z-indexes which exceeds the maximum of 1 (projectwallace/max-unique-z-indexes)`,
 	)
 })
 
@@ -93,7 +93,7 @@ test('should report on the declaration that pushed over the limit', async () => 
 	const { warnings } = await lint(`a { z-index: 1; } b { z-index: 2; } c { z-index: 3; }`, 2)
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0].text).toBe(
-		`Found 3 unique z-indexes (1, 2, 3) which exceeds the maximum of 2 (projectwallace/max-unique-z-indexes)`,
+		`Found 3 unique z-indexes which exceeds the maximum of 2 (projectwallace/max-unique-z-indexes)`,
 	)
 })
 
@@ -109,7 +109,7 @@ test('should report negative z-index values as unique', async () => {
 	const { warnings } = await lint(`a { z-index: 1; } b { z-index: -1; }`, 1)
 	expect(warnings).toHaveLength(1)
 	expect(warnings[0].text).toBe(
-		`Found 2 unique z-indexes (1, -1) which exceeds the maximum of 1 (projectwallace/max-unique-z-indexes)`,
+		`Found 2 unique z-indexes which exceeds the maximum of 1 (projectwallace/max-unique-z-indexes)`,
 	)
 })
 

--- a/src/rules/max-unique-z-indexes/index.ts
+++ b/src/rules/max-unique-z-indexes/index.ts
@@ -13,8 +13,8 @@ const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/max-unique-z-indexes'
 
 const messages = utils.ruleMessages(rule_name, {
-	rejected: (actual: number, expected: number, zindexes: string[]) =>
-		`Found ${actual} unique z-indexes (${zindexes.join(', ')}) which exceeds the maximum of ${expected}`,
+	rejected: (actual: number, expected: number) =>
+		`Found ${actual} unique z-indexes which exceeds the maximum of ${expected}`,
 })
 
 const meta = {
@@ -69,7 +69,7 @@ const ruleFunction = (primaryOption: number, secondaryOptions?: SecondaryOptions
 		const actual = unique_zindexes.size
 		for (const declaration of violating_declarations) {
 			utils.report({
-				message: messages.rejected(actual, primaryOption, [...unique_zindexes]),
+				message: messages.rejected(actual, primaryOption),
 				node: declaration,
 				result,
 				ruleName: rule_name,


### PR DESCRIPTION
Terminals were absolutely crammed full and also the wallace linter page on the website (WIP) was hardly usable because of it.