### PR TITLE
Increase max nesting depth from 1 to 3

### DIFF
--- a/src/configs/maintainability.ts
+++ b/src/configs/maintainability.ts
@@ -12,7 +12,7 @@ export default {
 		'projectwallace/max-average-selector-specificity': [0.02, 2.5, 1],
 		'projectwallace/max-declarations-per-rule': 15,
 		'projectwallace/max-important-ratio': 0.1,
-		'projectwallace/max-nesting-depth': 1,
+		'projectwallace/max-nesting-depth': 3,
 		'projectwallace/max-selector-complexity': 15,
 		'projectwallace/max-selectors-per-rule': 10,
 		'projectwallace/max-selector-specificity': [0, 5, 0],

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -6,7 +6,7 @@ export default {
 		'projectwallace/max-selectors': 2500,
 		'projectwallace/max-declarations': 5000,
 		'projectwallace/max-lines-of-code': 10_000,
-		'projectwallace/max-nesting-depth': 1,
+		'projectwallace/max-nesting-depth': 3,
 		'projectwallace/max-selector-complexity': 15,
 		'projectwallace/max-selector-specificity': [0, 5, 0],
 		'projectwallace/no-anonymous-layers': true,


### PR DESCRIPTION
max 1 is  bloody annoying because you'll hit limits immediately after trying to use a nested `@media print` rule or similar.