### PR TITLE
Add disallow option to no-property-shorthand rule

### DIFF
--- a/src/configs/maintainability.ts
+++ b/src/configs/maintainability.ts
@@ -33,7 +33,7 @@ export default {
 		],
 		'projectwallace/no-prefixed-values': true,
 		'projectwallace/no-property-browserhacks': true,
-		'projectwallace/no-property-shorthand': [true, { ignore: ['single-value'] }],
+		'projectwallace/no-property-shorthand': [true, { disallow: ['animation', 'background', 'flex', 'font', 'grid', 'transition'], ignore: ['single-value'] }],
 		'projectwallace/max-comments': [64, { ignoreCopyrightComments: true }],
 		'projectwallace/max-spacing-resets': 16,
 	},

--- a/src/configs/maintainability.ts
+++ b/src/configs/maintainability.ts
@@ -33,7 +33,13 @@ export default {
 		],
 		'projectwallace/no-prefixed-values': true,
 		'projectwallace/no-property-browserhacks': true,
-		'projectwallace/no-property-shorthand': [true, { disallow: ['animation', 'background', 'flex', 'font', 'grid', 'transition'], ignore: ['single-value'] }],
+		'projectwallace/no-property-shorthand': [
+			true,
+			{
+				disallow: ['animation', 'background', 'flex', 'font', 'grid', 'transition'],
+				ignore: ['single-value'],
+			},
+		],
 		'projectwallace/max-comments': [64, { ignoreCopyrightComments: true }],
 		'projectwallace/max-spacing-resets': 16,
 	},

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -19,7 +19,13 @@ export default {
 		],
 		'projectwallace/no-prefixed-values': true,
 		'projectwallace/no-property-browserhacks': true,
-		'projectwallace/no-property-shorthand': [true, { disallow: ['animation', 'background', 'flex', 'font', 'grid', 'transition'], ignore: ['single-value'] }],
+		'projectwallace/no-property-shorthand': [
+			true,
+			{
+				disallow: ['animation', 'background', 'flex', 'font', 'grid', 'transition'],
+				ignore: ['single-value'],
+			},
+		],
 		'projectwallace/no-pseudo-elements-in-is-where': true,
 		'projectwallace/no-static-container-queries': true,
 		'projectwallace/no-static-media-queries': true,

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -19,7 +19,7 @@ export default {
 		],
 		'projectwallace/no-prefixed-values': true,
 		'projectwallace/no-property-browserhacks': true,
-		'projectwallace/no-property-shorthand': [true, { ignore: ['single-value'] }],
+		'projectwallace/no-property-shorthand': [true, { disallow: ['animation', 'background', 'flex', 'font', 'grid', 'transition'], ignore: ['single-value'] }],
 		'projectwallace/no-pseudo-elements-in-is-where': true,
 		'projectwallace/no-static-container-queries': true,
 		'projectwallace/no-static-media-queries': true,

--- a/src/rules/no-property-shorthand/README.md
+++ b/src/rules/no-property-shorthand/README.md
@@ -34,6 +34,56 @@ a {
 
 ## Options
 
+### `disallow: Array<string | RegExp>`
+
+Restricts the rule to only flag the specified shorthand properties. When set, all other shorthands are permitted. Accepts exact strings, regular expressions, or strings wrapped in `/` delimiters treated as regular expressions.
+
+This is the inverse of `ignore` — instead of listing every shorthand you want to allow, you list only the few you want to forbid.
+
+<!-- prettier-ignore -->
+```json
+[true, { "disallow": ["font", "animation", "transition"] }]
+```
+
+The following are _not_ considered violations when `disallow: ["font", "animation", "transition"]` is set:
+
+<!-- prettier-ignore -->
+```css
+a {
+	background: red;
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a {
+	border: 1px solid red;
+}
+```
+
+The following _are_ still violations:
+
+<!-- prettier-ignore -->
+```css
+a {
+	font: bold 16px/1.5 sans-serif;
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a {
+	animation: foo 1s ease;
+}
+```
+
+`disallow` can be combined with `ignore: ["single-value"]` to additionally exempt single-value declarations from the disallowed set:
+
+<!-- prettier-ignore -->
+```json
+[true, { "disallow": ["font"], "ignore": ["single-value"] }]
+```
+
 ### `ignore: Array<string | RegExp | "single-value">`
 
 Allows specific shorthand properties or patterns to be used. Accepts exact strings, regular expressions, the special keyword `"single-value"`, or strings wrapped in `/` delimiters (e.g. `"/^border/"`) which are treated as regular expressions — enabling regex patterns in JSON config files.

--- a/src/rules/no-property-shorthand/index.test.ts
+++ b/src/rules/no-property-shorthand/index.test.ts
@@ -287,6 +287,23 @@ test('should combine disallow with ignore single-value', async () => {
 	expect(warnings[0].text).toBe(`Unexpected shorthand property "font" (${rule_name})`)
 })
 
+test('should not flag a property that is in both disallow and ignore', async () => {
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `a { font: bold 16px sans-serif }`,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[rule_name]: [true, { disallow: ['font'], ignore: ['font'] }],
+			},
+		},
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
 test('should combine "single-value" with property name ignores', async () => {
 	const {
 		results: [{ warnings, errored }],

--- a/src/rules/no-property-shorthand/index.test.ts
+++ b/src/rules/no-property-shorthand/index.test.ts
@@ -216,6 +216,77 @@ test('should still error on multi-value shorthands when "single-value" is ignore
 	expect(warnings).toHaveLength(1)
 })
 
+test('should only flag properties in the disallow list', async () => {
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `a { font: bold 16px sans-serif; animation: foo 1s; background: red }`,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[rule_name]: [true, { disallow: ['font', 'animation'] }],
+			},
+		},
+	})
+
+	expect(errored).toBe(true)
+	expect(warnings).toHaveLength(2)
+	expect(warnings[0].text).toBe(`Unexpected shorthand property "font" (${rule_name})`)
+	expect(warnings[1].text).toBe(`Unexpected shorthand property "animation" (${rule_name})`)
+})
+
+test('should not flag shorthands not in the disallow list', async () => {
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `a { background: red; border: 1px solid blue }`,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[rule_name]: [true, { disallow: ['font'] }],
+			},
+		},
+	})
+
+	expect(errored).toBe(false)
+	expect(warnings).toStrictEqual([])
+})
+
+test('should support RegExp patterns in disallow', async () => {
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `a { border: 1px solid red; border-radius: 4px; background: red }`,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[rule_name]: [true, { disallow: [/^border/] }],
+			},
+		},
+	})
+
+	expect(errored).toBe(true)
+	expect(warnings).toHaveLength(2)
+})
+
+test('should combine disallow with ignore single-value', async () => {
+	const {
+		results: [{ warnings, errored }],
+	} = await stylelint.lint({
+		code: `a { font: inherit; font: bold 16px sans-serif }`,
+		config: {
+			plugins: [plugin],
+			rules: {
+				[rule_name]: [true, { disallow: ['font'], ignore: ['single-value'] }],
+			},
+		},
+	})
+
+	expect(errored).toBe(true)
+	expect(warnings).toHaveLength(1)
+	expect(warnings[0].text).toBe(`Unexpected shorthand property "font" (${rule_name})`)
+})
+
 test('should combine "single-value" with property name ignores', async () => {
 	const {
 		results: [{ warnings, errored }],

--- a/src/rules/no-property-shorthand/index.ts
+++ b/src/rules/no-property-shorthand/index.ts
@@ -18,6 +18,7 @@ const meta = {
 
 interface SecondaryOptions {
 	ignore?: Array<string | RegExp>
+	disallow?: Array<string | RegExp>
 }
 
 const not_custom_property = /^(?!--)/
@@ -34,7 +35,10 @@ const ruleFunction = (primaryOption: true, secondaryOptions?: SecondaryOptions) 
 			{ actual: primaryOption, possible: [true] },
 			{
 				actual: secondaryOptions,
-				possible: { ignore: [...ignore_option_validators, (v: unknown) => v === 'single-value'] },
+				possible: {
+					ignore: [...ignore_option_validators, (v: unknown) => v === 'single-value'],
+					disallow: ignore_option_validators,
+				},
 				optional: true,
 			},
 		)
@@ -44,6 +48,7 @@ const ruleFunction = (primaryOption: true, secondaryOptions?: SecondaryOptions) 
 		}
 
 		const ignore = secondaryOptions?.ignore ?? []
+		const disallow = secondaryOptions?.disallow ?? []
 		const ignore_single_value = ignore.includes('single-value')
 		const property_ignore = ignore.filter((x) => x !== 'single-value')
 
@@ -51,17 +56,19 @@ const ruleFunction = (primaryOption: true, secondaryOptions?: SecondaryOptions) 
 			const property = declaration.prop.toLowerCase()
 
 			if (!shorthand_properties.has(property)) {
-				// Not a shorthand property
 				return
 			}
 
 			if (ignore_single_value && is_single_value(declaration.value)) {
-				// Single value and allowed to ignore
+				return
+			}
+
+			if (disallow.length > 0 && !is_allowed(property, disallow)) {
+				// disallow is set but this property is not in it — skip
 				return
 			}
 
 			if (property_ignore.length > 0 && is_allowed(property, property_ignore)) {
-				// This property is ignored
 				return
 			}
 


### PR DESCRIPTION
## Summary
This PR adds a new `disallow` option to the `no-property-shorthand` rule, providing an inverse way to configure which shorthand properties should be flagged. Instead of listing all properties to ignore, users can now specify only the properties they want to disallow.

## Key Changes
- **New `disallow` option**: Accepts an array of strings or RegExp patterns to specify which shorthand properties should trigger violations
- **Inverse logic**: When `disallow` is set, only the specified properties are flagged; all others are permitted
- **RegExp support**: Supports both exact string matches and regular expression patterns (including `/pattern/` syntax for JSON configs)
- **Composability**: The `disallow` option works alongside the existing `ignore` option, allowing fine-grained control (e.g., disallow a property but ignore its single-value declarations)
- **Updated configs**: Both `recommended` and `maintainability` configs now use `disallow` to explicitly list problematic shorthands (`animation`, `background`, `flex`, `font`, `grid`, `transition`) while still ignoring single-value declarations
- **Comprehensive tests**: Added 5 new test cases covering:
  - Basic disallow functionality
  - Properties not in the disallow list
  - RegExp pattern matching
  - Combination with `ignore: ['single-value']`
  - Interaction between disallow and ignore lists

## Implementation Details
- The `disallow` option is validated using the same validators as the `ignore` option
- When `disallow` is empty (default), the rule behaves as before
- If `disallow` is set, a property must be in the disallow list to be flagged (unless also ignored)
- The ignore list takes precedence: if a property is in both `disallow` and `ignore`, it won't be flagged

https://claude.ai/code/session_017nrroM34u3h3eVNrK4urVs