### PR TITLE
Add support for stylelint referenceFiles in all rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
           - node: 22
             stylelint: '16'
           - node: 22
+            stylelint: '17.0'
+          - node: 22
             stylelint: '17'
           - node: 24
             stylelint: '17'
@@ -34,9 +36,11 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Override stylelint version
-        if: matrix.stylelint == '16'
-        run: pnpm add -D stylelint@16
+        if: matrix.stylelint != '17'
+        run: pnpm add -D stylelint@${{ matrix.stylelint }}
       - run: pnpm test
+        env:
+          STYLELINT_VERSION: ${{ matrix.stylelint }}
 
   typecheck:
     name: Type check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,6 @@ jobs:
           - node: 22
             stylelint: '16'
           - node: 22
-            stylelint: '17.0'
-          - node: 22
             stylelint: '17.8'
           - node: 22
             stylelint: '17'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
           - node: 22
             stylelint: '17.0'
           - node: 22
+            stylelint: '17.8'
+          - node: 22
             stylelint: '17'
           - node: 24
             stylelint: '17'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - node: 22
-            stylelint: '16'
+            stylelint: '16.26'
           - node: 22
             stylelint: '17.8'
           - node: 22

--- a/src/rules/no-unknown-container-names/index.test.ts
+++ b/src/rules/no-unknown-container-names/index.test.ts
@@ -1,6 +1,33 @@
 import stylelint from 'stylelint'
-import { test, expect } from 'vitest'
+import { createRequire } from 'node:module'
+import { test, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import plugin from './index.js'
+
+const _require = createRequire(import.meta.url)
+const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
+const [major, minor] = _stylelintVersion.split('.').map(Number)
+const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
+
+let tmp_dir: string
+
+function write_fixture(name: string, content: string): string {
+	if (!tmp_dir) {
+		tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-unknown-container-names-test-'))
+	}
+	const file_path = path.join(tmp_dir, name)
+	fs.writeFileSync(file_path, content, 'utf8')
+	return file_path
+}
+
+afterEach(() => {
+	if (tmp_dir) {
+		fs.rmSync(tmp_dir, { recursive: true, force: true })
+		tmp_dir = undefined!
+	}
+})
 
 const rule_name = 'projectwallace/no-unknown-container-names'
 
@@ -325,3 +352,44 @@ test('should error for each unique unknown container name', async () => {
 	expect(errored).toBe(true)
 	expect(warnings.length).toBe(2)
 })
+
+test.skipIf(!supportsReferenceFiles)(
+	'should not error when @container uses a name declared in a referenceFiles file',
+	async () => {
+		const file = write_fixture('layout.css', '.sidebar { container-name: sidebar; }')
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: '@container sidebar (min-width: 700px) { .card { font-size: 1rem; } }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test.skipIf(!supportsReferenceFiles)(
+	'should still error when @container uses a name not in any referenceFiles file',
+	async () => {
+		const file = write_fixture('layout.css', '.sidebar { container-name: sidebar; }')
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: '@container unknown (min-width: 700px) { .card { font-size: 1rem; } }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(true)
+		expect(warnings.length).toBe(1)
+		expect(warnings[0].text).toBe(
+			`Unexpected unknown container name "unknown" (${rule_name})`,
+		)
+	},
+)

--- a/src/rules/no-unknown-container-names/index.test.ts
+++ b/src/rules/no-unknown-container-names/index.test.ts
@@ -1,14 +1,12 @@
 import stylelint from 'stylelint'
-import { createRequire } from 'node:module'
 import { test, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import plugin from './index.js'
 
-const _require = createRequire(import.meta.url)
-const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
-const [major, minor] = _stylelintVersion.split('.').map(Number)
+import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
+const [major, minor] = stylelintPkg.version.split('.').map(Number)
 const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
 
 let tmp_dir: string
@@ -353,7 +351,7 @@ test('should error for each unique unknown container name', async () => {
 	expect(warnings.length).toBe(2)
 })
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should not error when @container uses a name declared in a referenceFiles file',
 	async () => {
 		const file = write_fixture('layout.css', '.sidebar { container-name: sidebar; }')
@@ -372,7 +370,7 @@ test.skipIf(!supportsReferenceFiles)(
 	},
 )
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should still error when @container uses a name not in any referenceFiles file',
 	async () => {
 		const file = write_fixture('layout.css', '.sidebar { container-name: sidebar; }')

--- a/src/rules/no-unknown-container-names/index.test.ts
+++ b/src/rules/no-unknown-container-names/index.test.ts
@@ -1,31 +1,9 @@
 import stylelint from 'stylelint'
-import { test, expect, afterEach } from 'vitest'
-import fs from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
+import { test, expect } from 'vitest'
 import plugin from './index.js'
+import { supportsReferenceFiles, createFixtures } from '../test-utils.js'
 
-import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
-const [major, minor] = stylelintPkg.version.split('.').map(Number)
-const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
-
-let tmp_dir: string
-
-function write_fixture(name: string, content: string): string {
-	if (!tmp_dir) {
-		tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-unknown-container-names-test-'))
-	}
-	const file_path = path.join(tmp_dir, name)
-	fs.writeFileSync(file_path, content, 'utf8')
-	return file_path
-}
-
-afterEach(() => {
-	if (tmp_dir) {
-		fs.rmSync(tmp_dir, { recursive: true, force: true })
-		tmp_dir = undefined!
-	}
-})
+const write_fixture = createFixtures('no-unknown-container-names-test-')
 
 const rule_name = 'projectwallace/no-unknown-container-names'
 

--- a/src/rules/no-unknown-container-names/index.test.ts
+++ b/src/rules/no-unknown-container-names/index.test.ts
@@ -386,8 +386,6 @@ test.runIf(supportsReferenceFiles)(
 		})
 		expect(errored).toBe(true)
 		expect(warnings.length).toBe(1)
-		expect(warnings[0].text).toBe(
-			`Unexpected unknown container name "unknown" (${rule_name})`,
-		)
+		expect(warnings[0].text).toBe(`Unexpected unknown container name "unknown" (${rule_name})`)
 	},
 )

--- a/src/rules/no-unknown-container-names/index.ts
+++ b/src/rules/no-unknown-container-names/index.ts
@@ -56,8 +56,8 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 
 		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
 		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
-		for (const refRoot of referenceRoots) {
-			collect_container_names(refRoot, declared_names)
+		for (const referenceRoot of referenceRoots) {
+			collect_container_names(referenceRoot, declared_names)
 		}
 
 		root.walkAtRules('container', (atRule) => {

--- a/src/rules/no-unknown-container-names/index.ts
+++ b/src/rules/no-unknown-container-names/index.ts
@@ -6,6 +6,23 @@ import { parse_atrule_prelude } from '@projectwallace/css-parser/parse-atrule-pr
 import { keywords } from '@projectwallace/css-analyzer/values'
 import { is_allowed } from '../../utils/option-validators.js'
 
+function collect_container_names(root: Root, declared: Set<string>): void {
+	root.walkDecls(/^container(-name)?$/i, (decl) => {
+		if (keywords.has(decl.value.trim())) {
+			return
+		}
+		const ast = parse_value(decl.value)
+		for (const node of ast) {
+			if (node.type === OPERATOR) {
+				break
+			}
+			if (node.type === IDENTIFIER) {
+				declared.add(node.text)
+			}
+		}
+	})
+}
+
 const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-unknown-container-names'
@@ -35,20 +52,13 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 
 		const declared_names = new Set<string>()
 
-		root.walkDecls(/^container(-name)?$/i, (decl) => {
-			if (keywords.has(decl.value.trim())) {
-				return
-			}
-			const ast = parse_value(decl.value)
-			for (const node of ast) {
-				if (node.type === OPERATOR) {
-					break
-				}
-				if (node.type === IDENTIFIER) {
-					declared_names.add(node.text)
-				}
-			}
-		})
+		collect_container_names(root, declared_names)
+
+		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
+		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
+		for (const refRoot of referenceRoots) {
+			collect_container_names(refRoot, declared_names)
+		}
 
 		root.walkAtRules('container', (atRule) => {
 			const prelude = parse_atrule_prelude('container', atRule.params.trim())

--- a/src/rules/no-unknown-custom-properties/index.test.ts
+++ b/src/rules/no-unknown-custom-properties/index.test.ts
@@ -1,9 +1,15 @@
 import stylelint from 'stylelint'
+import { createRequire } from 'node:module'
 import { test, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import plugin from './index.js'
+
+const _require = createRequire(import.meta.url)
+const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
+const [major, minor] = _stylelintVersion.split('.').map(Number)
+const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
 
 let tmp_dir: string
 
@@ -391,6 +397,69 @@ test('should still error when var() uses a property not present in any importFro
 		`Unexpected unknown custom property "--not-in-tokens" (${rule_name})`,
 	)
 })
+
+test.skipIf(!supportsReferenceFiles)(
+	'should not error when var() uses a property declared in a referenceFiles file',
+	async () => {
+		const file = write_fixture('tokens.css', ':root { --token-color: red; }')
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: 'a { color: var(--token-color); }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test.skipIf(!supportsReferenceFiles)(
+	'should not error when var() uses a property declared via @property in a referenceFiles file',
+	async () => {
+		const file = write_fixture(
+			'tokens.css',
+			`@property --token-color { syntax: '<color>'; initial-value: red; inherits: false; }`,
+		)
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: 'a { color: var(--token-color); }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test.skipIf(!supportsReferenceFiles)(
+	'should still error when var() uses a property not in any referenceFiles file',
+	async () => {
+		const file = write_fixture('tokens.css', ':root { --token-color: red; }')
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: 'a { color: var(--token-color); background: var(--not-in-tokens); }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(true)
+		expect(warnings.length).toBe(1)
+		expect(warnings[0].text).toBe(
+			`Unexpected unknown custom property "--not-in-tokens" (${rule_name})`,
+		)
+	},
+)
 
 test('should not error when declared properties are used inside light-dark()', async () => {
 	const config = {

--- a/src/rules/no-unknown-custom-properties/index.test.ts
+++ b/src/rules/no-unknown-custom-properties/index.test.ts
@@ -1,14 +1,12 @@
 import stylelint from 'stylelint'
-import { createRequire } from 'node:module'
 import { test, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import plugin from './index.js'
 
-const _require = createRequire(import.meta.url)
-const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
-const [major, minor] = _stylelintVersion.split('.').map(Number)
+import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
+const [major, minor] = stylelintPkg.version.split('.').map(Number)
 const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
 
 let tmp_dir: string
@@ -398,7 +396,7 @@ test('should still error when var() uses a property not present in any importFro
 	)
 })
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should not error when var() uses a property declared in a referenceFiles file',
 	async () => {
 		const file = write_fixture('tokens.css', ':root { --token-color: red; }')
@@ -417,7 +415,7 @@ test.skipIf(!supportsReferenceFiles)(
 	},
 )
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should not error when var() uses a property declared via @property in a referenceFiles file',
 	async () => {
 		const file = write_fixture(
@@ -439,7 +437,7 @@ test.skipIf(!supportsReferenceFiles)(
 	},
 )
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should still error when var() uses a property not in any referenceFiles file',
 	async () => {
 		const file = write_fixture('tokens.css', ':root { --token-color: red; }')

--- a/src/rules/no-unknown-custom-properties/index.test.ts
+++ b/src/rules/no-unknown-custom-properties/index.test.ts
@@ -1,31 +1,9 @@
 import stylelint from 'stylelint'
-import { test, expect, afterEach } from 'vitest'
-import fs from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
+import { test, expect } from 'vitest'
 import plugin from './index.js'
+import { supportsReferenceFiles, createFixtures } from '../test-utils.js'
 
-import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
-const [major, minor] = stylelintPkg.version.split('.').map(Number)
-const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
-
-let tmp_dir: string
-
-function write_fixture(name: string, content: string): string {
-	if (!tmp_dir) {
-		tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-unknown-cp-test-'))
-	}
-	const file_path = path.join(tmp_dir, name)
-	fs.writeFileSync(file_path, content, 'utf8')
-	return file_path
-}
-
-afterEach(() => {
-	if (tmp_dir) {
-		fs.rmSync(tmp_dir, { recursive: true, force: true })
-		tmp_dir = undefined!
-	}
-})
+const write_fixture = createFixtures('no-unknown-cp-test-')
 
 const rule_name = 'projectwallace/no-unknown-custom-properties'
 

--- a/src/rules/no-unknown-custom-properties/index.ts
+++ b/src/rules/no-unknown-custom-properties/index.ts
@@ -14,10 +14,8 @@ function collect_declared_properties(root: Root, declared: Set<string>): void {
 			declared.add(property_name)
 		}
 	})
-	root.walkDecls((decl) => {
-		if (decl.prop.startsWith('--')) {
-			declared.add(decl.prop)
-		}
+	root.walkDecls(/^--/, (decl) => {
+		declared.add(decl.prop)
 	})
 }
 
@@ -62,8 +60,8 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 
 		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
 		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
-		for (const refRoot of referenceRoots) {
-			collect_declared_properties(refRoot, declared_properties)
+		for (const referenceRoot of referenceRoots) {
+			collect_declared_properties(referenceRoot, declared_properties)
 		}
 
 		root.walkDecls((decl) => {

--- a/src/rules/no-unknown-custom-properties/index.ts
+++ b/src/rules/no-unknown-custom-properties/index.ts
@@ -7,6 +7,20 @@ import { collect_declarations_from_files } from '../../utils/import-from.js'
 import type { ImportFrom } from '../../utils/import-from.js'
 import { is_allowed } from '../../utils/option-validators.js'
 
+function collect_declared_properties(root: Root, declared: Set<string>): void {
+	root.walkAtRules('property', (atRule) => {
+		const property_name = atRule.params.trim()
+		if (property_name.startsWith('--')) {
+			declared.add(property_name)
+		}
+	})
+	root.walkDecls((decl) => {
+		if (decl.prop.startsWith('--')) {
+			declared.add(decl.prop)
+		}
+	})
+}
+
 const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-unknown-custom-properties'
@@ -38,23 +52,18 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 
 		const declared_properties = new Set<string>()
 
-		root.walkAtRules('property', (atRule) => {
-			const property_name = atRule.params.trim()
-			if (property_name.startsWith('--')) {
-				declared_properties.add(property_name)
-			}
-		})
-
-		root.walkDecls((decl) => {
-			if (decl.prop.startsWith('--')) {
-				declared_properties.add(decl.prop)
-			}
-		})
+		collect_declared_properties(root, declared_properties)
 
 		if (secondaryOptions?.importFrom?.length) {
 			for (const name of collect_declarations_from_files(secondaryOptions.importFrom)) {
 				declared_properties.add(name)
 			}
+		}
+
+		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
+		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
+		for (const refRoot of referenceRoots) {
+			collect_declared_properties(refRoot, declared_properties)
 		}
 
 		root.walkDecls((decl) => {

--- a/src/rules/no-unused-container-names/index.test.ts
+++ b/src/rules/no-unused-container-names/index.test.ts
@@ -1,14 +1,12 @@
 import stylelint from 'stylelint'
-import { createRequire } from 'node:module'
 import { test, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import plugin from './index.js'
 
-const _require = createRequire(import.meta.url)
-const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
-const [major, minor] = _stylelintVersion.split('.').map(Number)
+import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
+const [major, minor] = stylelintPkg.version.split('.').map(Number)
 const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
 
 let tmp_dir: string
@@ -322,7 +320,7 @@ test('should still error when ignore does not match the unused container name', 
 	expect(warnings[0].text).toBe(`Unexpected unused container name "sidebar" (${rule_name})`)
 })
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should not error when container name is declared but queried in a referenceFiles file',
 	async () => {
 		const file = write_fixture(
@@ -344,7 +342,7 @@ test.skipIf(!supportsReferenceFiles)(
 	},
 )
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should still error when container name is declared and not queried anywhere including referenceFiles',
 	async () => {
 		const file = write_fixture(

--- a/src/rules/no-unused-container-names/index.test.ts
+++ b/src/rules/no-unused-container-names/index.test.ts
@@ -1,6 +1,33 @@
 import stylelint from 'stylelint'
-import { test, expect } from 'vitest'
+import { createRequire } from 'node:module'
+import { test, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import plugin from './index.js'
+
+const _require = createRequire(import.meta.url)
+const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
+const [major, minor] = _stylelintVersion.split('.').map(Number)
+const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
+
+let tmp_dir: string
+
+function write_fixture(name: string, content: string): string {
+	if (!tmp_dir) {
+		tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-unused-container-names-test-'))
+	}
+	const file_path = path.join(tmp_dir, name)
+	fs.writeFileSync(file_path, content, 'utf8')
+	return file_path
+}
+
+afterEach(() => {
+	if (tmp_dir) {
+		fs.rmSync(tmp_dir, { recursive: true, force: true })
+		tmp_dir = undefined!
+	}
+})
 
 const rule_name = 'projectwallace/no-unused-container-names'
 
@@ -294,3 +321,48 @@ test('should still error when ignore does not match the unused container name', 
 	expect(warnings.length).toBe(1)
 	expect(warnings[0].text).toBe(`Unexpected unused container name "sidebar" (${rule_name})`)
 })
+
+test.skipIf(!supportsReferenceFiles)(
+	'should not error when container name is declared but queried in a referenceFiles file',
+	async () => {
+		const file = write_fixture(
+			'component.css',
+			'@container sidebar (min-width: 700px) { .card { font-size: 1rem; } }',
+		)
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: '.sidebar { container-name: sidebar; }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test.skipIf(!supportsReferenceFiles)(
+	'should still error when container name is declared and not queried anywhere including referenceFiles',
+	async () => {
+		const file = write_fixture(
+			'component.css',
+			'@container other (min-width: 700px) { .card { font-size: 1rem; } }',
+		)
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: '.sidebar { container-name: sidebar; }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(true)
+		expect(warnings.length).toBe(1)
+		expect(warnings[0].text).toBe(`Unexpected unused container name "sidebar" (${rule_name})`)
+	},
+)

--- a/src/rules/no-unused-container-names/index.test.ts
+++ b/src/rules/no-unused-container-names/index.test.ts
@@ -1,31 +1,9 @@
 import stylelint from 'stylelint'
-import { test, expect, afterEach } from 'vitest'
-import fs from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
+import { test, expect } from 'vitest'
 import plugin from './index.js'
+import { supportsReferenceFiles, createFixtures } from '../test-utils.js'
 
-import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
-const [major, minor] = stylelintPkg.version.split('.').map(Number)
-const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
-
-let tmp_dir: string
-
-function write_fixture(name: string, content: string): string {
-	if (!tmp_dir) {
-		tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-unused-container-names-test-'))
-	}
-	const file_path = path.join(tmp_dir, name)
-	fs.writeFileSync(file_path, content, 'utf8')
-	return file_path
-}
-
-afterEach(() => {
-	if (tmp_dir) {
-		fs.rmSync(tmp_dir, { recursive: true, force: true })
-		tmp_dir = undefined!
-	}
-})
+const write_fixture = createFixtures('no-unused-container-names-test-')
 
 const rule_name = 'projectwallace/no-unused-container-names'
 

--- a/src/rules/no-unused-container-names/index.ts
+++ b/src/rules/no-unused-container-names/index.ts
@@ -61,8 +61,8 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 
 		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
 		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
-		for (const refRoot of referenceRoots) {
-			refRoot.walkAtRules('container', (atRule) => {
+		for (const referenceRoot of referenceRoots) {
+			referenceRoot.walkAtRules('container', (atRule) => {
 				const prelude = parse_atrule_prelude('container', atRule.params.trim())
 				const first_child = prelude.at(0)?.first_child
 				if (first_child?.type === IDENTIFIER) {

--- a/src/rules/no-unused-container-names/index.ts
+++ b/src/rules/no-unused-container-names/index.ts
@@ -59,6 +59,18 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 			}
 		})
 
+		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
+		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
+		for (const refRoot of referenceRoots) {
+			refRoot.walkAtRules('container', (atRule) => {
+				const prelude = parse_atrule_prelude('container', atRule.params.trim())
+				const first_child = prelude.at(0)?.first_child
+				if (first_child?.type === IDENTIFIER) {
+					tracker.use(first_child.text)
+				}
+			})
+		}
+
 		for (const [name, node] of tracker.unused()) {
 			if (secondaryOptions?.ignore && is_allowed(name, secondaryOptions.ignore)) {
 				continue

--- a/src/rules/no-unused-custom-properties/index.test.ts
+++ b/src/rules/no-unused-custom-properties/index.test.ts
@@ -1,14 +1,12 @@
 import stylelint from 'stylelint'
-import { createRequire } from 'node:module'
 import { test, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import plugin from './index.js'
 
-const _require = createRequire(import.meta.url)
-const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
-const [major, minor] = _stylelintVersion.split('.').map(Number)
+import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
+const [major, minor] = stylelintPkg.version.split('.').map(Number)
 const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
 
 let tmp_dir: string
@@ -364,7 +362,7 @@ test('should not error when a declared property is used inside light-dark()', as
 	expect(warnings).toStrictEqual([])
 })
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should not error when custom property is declared but used in a referenceFiles file',
 	async () => {
 		const file = write_fixture('component.css', 'a { color: var(--color); }')
@@ -383,7 +381,7 @@ test.skipIf(!supportsReferenceFiles)(
 	},
 )
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should still error when custom property is declared and not used anywhere including referenceFiles',
 	async () => {
 		const file = write_fixture('component.css', 'a { color: var(--other); }')

--- a/src/rules/no-unused-custom-properties/index.test.ts
+++ b/src/rules/no-unused-custom-properties/index.test.ts
@@ -1,31 +1,9 @@
 import stylelint from 'stylelint'
-import { test, expect, afterEach } from 'vitest'
-import fs from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
+import { test, expect } from 'vitest'
 import plugin from './index.js'
+import { supportsReferenceFiles, createFixtures } from '../test-utils.js'
 
-import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
-const [major, minor] = stylelintPkg.version.split('.').map(Number)
-const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
-
-let tmp_dir: string
-
-function write_fixture(name: string, content: string): string {
-	if (!tmp_dir) {
-		tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-unused-cp-test-'))
-	}
-	const file_path = path.join(tmp_dir, name)
-	fs.writeFileSync(file_path, content, 'utf8')
-	return file_path
-}
-
-afterEach(() => {
-	if (tmp_dir) {
-		fs.rmSync(tmp_dir, { recursive: true, force: true })
-		tmp_dir = undefined!
-	}
-})
+const write_fixture = createFixtures('no-unused-cp-test-')
 
 const rule_name = 'projectwallace/no-unused-custom-properties'
 

--- a/src/rules/no-unused-custom-properties/index.test.ts
+++ b/src/rules/no-unused-custom-properties/index.test.ts
@@ -1,9 +1,15 @@
 import stylelint from 'stylelint'
+import { createRequire } from 'node:module'
 import { test, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import plugin from './index.js'
+
+const _require = createRequire(import.meta.url)
+const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
+const [major, minor] = _stylelintVersion.split('.').map(Number)
+const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
 
 let tmp_dir: string
 
@@ -357,3 +363,42 @@ test('should not error when a declared property is used inside light-dark()', as
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
+
+test.skipIf(!supportsReferenceFiles)(
+	'should not error when custom property is declared but used in a referenceFiles file',
+	async () => {
+		const file = write_fixture('component.css', 'a { color: var(--color); }')
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: ':root { --color: red; }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test.skipIf(!supportsReferenceFiles)(
+	'should still error when custom property is declared and not used anywhere including referenceFiles',
+	async () => {
+		const file = write_fixture('component.css', 'a { color: var(--other); }')
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: ':root { --color: red; }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(true)
+		expect(warnings.length).toBe(1)
+		expect(warnings[0].text).toBe(`Unexpected unused custom property "--color" (${rule_name})`)
+	},
+)

--- a/src/rules/no-unused-custom-properties/index.ts
+++ b/src/rules/no-unused-custom-properties/index.ts
@@ -68,6 +68,22 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 			}
 		}
 
+		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
+		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
+		for (const refRoot of referenceRoots) {
+			refRoot.walkDecls((decl) => {
+				walk(parse_value(decl.value), (node) => {
+					if (node.type !== FUNCTION || node.name !== 'var') {
+						return
+					}
+					const first = node.first_child
+					if (first !== null && first.type === IDENTIFIER && first.text.startsWith('--')) {
+						tracker.use(first.text)
+					}
+				})
+			})
+		}
+
 		for (const [prop, node] of tracker.unused()) {
 			if (secondaryOptions?.ignore && is_allowed(prop, secondaryOptions.ignore)) {
 				continue

--- a/src/rules/no-unused-custom-properties/index.ts
+++ b/src/rules/no-unused-custom-properties/index.ts
@@ -70,8 +70,8 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 
 		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
 		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
-		for (const refRoot of referenceRoots) {
-			refRoot.walkDecls((decl) => {
+		for (const referenceRoot of referenceRoots) {
+			referenceRoot.walkDecls((decl) => {
 				walk(parse_value(decl.value), (node) => {
 					if (node.type !== FUNCTION || node.name !== 'var') {
 						return

--- a/src/rules/no-unused-keyframes/index.test.ts
+++ b/src/rules/no-unused-keyframes/index.test.ts
@@ -1,31 +1,9 @@
 import stylelint from 'stylelint'
-import { test, expect, afterEach } from 'vitest'
-import fs from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
+import { test, expect } from 'vitest'
 import plugin from './index.js'
+import { supportsReferenceFiles, createFixtures } from '../test-utils.js'
 
-import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
-const [major, minor] = stylelintPkg.version.split('.').map(Number)
-const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
-
-let tmp_dir: string
-
-function write_fixture(name: string, content: string): string {
-	if (!tmp_dir) {
-		tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-unused-keyframes-test-'))
-	}
-	const file_path = path.join(tmp_dir, name)
-	fs.writeFileSync(file_path, content, 'utf8')
-	return file_path
-}
-
-afterEach(() => {
-	if (tmp_dir) {
-		fs.rmSync(tmp_dir, { recursive: true, force: true })
-		tmp_dir = undefined!
-	}
-})
+const write_fixture = createFixtures('no-unused-keyframes-test-')
 
 const rule_name = 'projectwallace/no-unused-keyframes'
 

--- a/src/rules/no-unused-keyframes/index.test.ts
+++ b/src/rules/no-unused-keyframes/index.test.ts
@@ -1,6 +1,33 @@
 import stylelint from 'stylelint'
-import { test, expect } from 'vitest'
+import { createRequire } from 'node:module'
+import { test, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import plugin from './index.js'
+
+const _require = createRequire(import.meta.url)
+const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
+const [major, minor] = _stylelintVersion.split('.').map(Number)
+const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
+
+let tmp_dir: string
+
+function write_fixture(name: string, content: string): string {
+	if (!tmp_dir) {
+		tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-unused-keyframes-test-'))
+	}
+	const file_path = path.join(tmp_dir, name)
+	fs.writeFileSync(file_path, content, 'utf8')
+	return file_path
+}
+
+afterEach(() => {
+	if (tmp_dir) {
+		fs.rmSync(tmp_dir, { recursive: true, force: true })
+		tmp_dir = undefined!
+	}
+})
 
 const rule_name = 'projectwallace/no-unused-keyframes'
 
@@ -249,3 +276,67 @@ test('should still error when ignore does not match the unused keyframe name', a
 	expect(warnings.length).toBe(1)
 	expect(warnings[0].text).toBe(`Unexpected unused keyframe "slide-in" (${rule_name})`)
 })
+
+test.skipIf(!supportsReferenceFiles)(
+	'should not error when keyframe is declared but used via animation-name in a referenceFiles file',
+	async () => {
+		const file = write_fixture(
+			'component.css',
+			'a { animation-name: slide-in; }',
+		)
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: '@keyframes slide-in { from { opacity: 0; } to { opacity: 1; } }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test.skipIf(!supportsReferenceFiles)(
+	'should not error when keyframe is declared but used via animation shorthand in a referenceFiles file',
+	async () => {
+		const file = write_fixture(
+			'component.css',
+			'a { animation: slide-in 1s linear; }',
+		)
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: '@keyframes slide-in { from { opacity: 0; } to { opacity: 1; } }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test.skipIf(!supportsReferenceFiles)(
+	'should still error when keyframe is declared and not used anywhere including referenceFiles',
+	async () => {
+		const file = write_fixture('component.css', 'a { animation-name: other; }')
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: '@keyframes slide-in { from { opacity: 0; } to { opacity: 1; } }',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(true)
+		expect(warnings.length).toBe(1)
+		expect(warnings[0].text).toBe(`Unexpected unused keyframe "slide-in" (${rule_name})`)
+	},
+)

--- a/src/rules/no-unused-keyframes/index.test.ts
+++ b/src/rules/no-unused-keyframes/index.test.ts
@@ -1,14 +1,12 @@
 import stylelint from 'stylelint'
-import { createRequire } from 'node:module'
 import { test, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import plugin from './index.js'
 
-const _require = createRequire(import.meta.url)
-const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
-const [major, minor] = _stylelintVersion.split('.').map(Number)
+import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
+const [major, minor] = stylelintPkg.version.split('.').map(Number)
 const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
 
 let tmp_dir: string
@@ -277,7 +275,7 @@ test('should still error when ignore does not match the unused keyframe name', a
 	expect(warnings[0].text).toBe(`Unexpected unused keyframe "slide-in" (${rule_name})`)
 })
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should not error when keyframe is declared but used via animation-name in a referenceFiles file',
 	async () => {
 		const file = write_fixture(
@@ -299,7 +297,7 @@ test.skipIf(!supportsReferenceFiles)(
 	},
 )
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should not error when keyframe is declared but used via animation shorthand in a referenceFiles file',
 	async () => {
 		const file = write_fixture(
@@ -321,7 +319,7 @@ test.skipIf(!supportsReferenceFiles)(
 	},
 )
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should still error when keyframe is declared and not used anywhere including referenceFiles',
 	async () => {
 		const file = write_fixture('component.css', 'a { animation-name: other; }')

--- a/src/rules/no-unused-keyframes/index.test.ts
+++ b/src/rules/no-unused-keyframes/index.test.ts
@@ -278,10 +278,7 @@ test('should still error when ignore does not match the unused keyframe name', a
 test.runIf(supportsReferenceFiles)(
 	'should not error when keyframe is declared but used via animation-name in a referenceFiles file',
 	async () => {
-		const file = write_fixture(
-			'component.css',
-			'a { animation-name: slide-in; }',
-		)
+		const file = write_fixture('component.css', 'a { animation-name: slide-in; }')
 		const {
 			results: [{ warnings, errored }],
 		} = await stylelint.lint({
@@ -300,10 +297,7 @@ test.runIf(supportsReferenceFiles)(
 test.runIf(supportsReferenceFiles)(
 	'should not error when keyframe is declared but used via animation shorthand in a referenceFiles file',
 	async () => {
-		const file = write_fixture(
-			'component.css',
-			'a { animation: slide-in 1s linear; }',
-		)
+		const file = write_fixture('component.css', 'a { animation: slide-in 1s linear; }')
 		const {
 			results: [{ warnings, errored }],
 		} = await stylelint.lint({

--- a/src/rules/no-unused-keyframes/index.ts
+++ b/src/rules/no-unused-keyframes/index.ts
@@ -78,6 +78,36 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 			}
 		})
 
+		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
+		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
+		for (const refRoot of referenceRoots) {
+			refRoot.walkDecls(/^animation-name$/i, (decl) => {
+				const ast = parse_value(decl.value)
+				for (const node of ast) {
+					if (node.type === IDENTIFIER) {
+						if (node.text.toLowerCase() !== 'none') {
+							tracker.use(node.text)
+						}
+					} else if (node.type === STRING) {
+						tracker.use(node.text)
+					}
+				}
+			})
+			refRoot.walkDecls(/^animation$/i, (decl) => {
+				const ast = parse_value(decl.value)
+				analyzeAnimation(ast, ({ type, value }) => {
+					if (type === 'name') {
+						tracker.use(value.text)
+					}
+				})
+				for (const node of ast) {
+					if (node.type === STRING) {
+						tracker.use(node.text)
+					}
+				}
+			})
+		}
+
 		for (const [name, node] of tracker.unused()) {
 			if (secondaryOptions?.ignore && is_allowed(name, secondaryOptions.ignore)) {
 				continue

--- a/src/rules/no-unused-keyframes/index.ts
+++ b/src/rules/no-unused-keyframes/index.ts
@@ -80,8 +80,8 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 
 		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
 		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
-		for (const refRoot of referenceRoots) {
-			refRoot.walkDecls(/^animation-name$/i, (decl) => {
+		for (const referenceRoot of referenceRoots) {
+			referenceRoot.walkDecls(/^animation-name$/i, (decl) => {
 				const ast = parse_value(decl.value)
 				for (const node of ast) {
 					if (node.type === IDENTIFIER) {
@@ -93,7 +93,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 					}
 				}
 			})
-			refRoot.walkDecls(/^animation$/i, (decl) => {
+			referenceRoot.walkDecls(/^animation$/i, (decl) => {
 				const ast = parse_value(decl.value)
 				analyzeAnimation(ast, ({ type, value }) => {
 					if (type === 'name') {

--- a/src/rules/no-unused-layers/index.test.ts
+++ b/src/rules/no-unused-layers/index.test.ts
@@ -1,6 +1,33 @@
 import stylelint from 'stylelint'
-import { test, expect } from 'vitest'
+import { createRequire } from 'node:module'
+import { test, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import plugin, { rule_name } from './index.js'
+
+const _require = createRequire(import.meta.url)
+const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
+const [major, minor] = _stylelintVersion.split('.').map(Number)
+const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
+
+let tmp_dir: string
+
+function write_fixture(name: string, content: string): string {
+	if (!tmp_dir) {
+		tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-unused-layers-test-'))
+	}
+	const file_path = path.join(tmp_dir, name)
+	fs.writeFileSync(file_path, content, 'utf8')
+	return file_path
+}
+
+afterEach(() => {
+	if (tmp_dir) {
+		fs.rmSync(tmp_dir, { recursive: true, force: true })
+		tmp_dir = undefined!
+	}
+})
 
 test('should not error when a declared layer is defined in a block', async () => {
 	const config = {
@@ -321,3 +348,45 @@ test('should not error when no layer statements exist', async () => {
 	expect(errored).toBe(false)
 	expect(warnings).toStrictEqual([])
 })
+
+test.skipIf(!supportsReferenceFiles)(
+	'should not error when layer is declared but used as a block layer in a referenceFiles file',
+	async () => {
+		const file = write_fixture(
+			'utilities.css',
+			'@layer utilities { .u-flex { display: flex; } }',
+		)
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: '@layer utilities;',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(false)
+		expect(warnings).toStrictEqual([])
+	},
+)
+
+test.skipIf(!supportsReferenceFiles)(
+	'should still error when layer is declared and not used anywhere including referenceFiles',
+	async () => {
+		const file = write_fixture('utilities.css', '@layer other { .u-flex { display: flex; } }')
+		const {
+			results: [{ warnings, errored }],
+		} = await stylelint.lint({
+			code: '@layer utilities;',
+			config: {
+				plugins: [plugin],
+				rules: { [rule_name]: true },
+				referenceFiles: [file],
+			},
+		})
+		expect(errored).toBe(true)
+		expect(warnings.length).toBe(1)
+		expect(warnings[0].text).toBe(`Unexpected unused layer "utilities" (${rule_name})`)
+	},
+)

--- a/src/rules/no-unused-layers/index.test.ts
+++ b/src/rules/no-unused-layers/index.test.ts
@@ -350,10 +350,7 @@ test('should not error when no layer statements exist', async () => {
 test.runIf(supportsReferenceFiles)(
 	'should not error when layer is declared but used as a block layer in a referenceFiles file',
 	async () => {
-		const file = write_fixture(
-			'utilities.css',
-			'@layer utilities { .u-flex { display: flex; } }',
-		)
+		const file = write_fixture('utilities.css', '@layer utilities { .u-flex { display: flex; } }')
 		const {
 			results: [{ warnings, errored }],
 		} = await stylelint.lint({

--- a/src/rules/no-unused-layers/index.test.ts
+++ b/src/rules/no-unused-layers/index.test.ts
@@ -1,14 +1,12 @@
 import stylelint from 'stylelint'
-import { createRequire } from 'node:module'
 import { test, expect, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import plugin, { rule_name } from './index.js'
 
-const _require = createRequire(import.meta.url)
-const _stylelintVersion: string = (_require('stylelint/package.json') as { version: string }).version
-const [major, minor] = _stylelintVersion.split('.').map(Number)
+import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
+const [major, minor] = stylelintPkg.version.split('.').map(Number)
 const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
 
 let tmp_dir: string
@@ -349,7 +347,7 @@ test('should not error when no layer statements exist', async () => {
 	expect(warnings).toStrictEqual([])
 })
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should not error when layer is declared but used as a block layer in a referenceFiles file',
 	async () => {
 		const file = write_fixture(
@@ -371,7 +369,7 @@ test.skipIf(!supportsReferenceFiles)(
 	},
 )
 
-test.skipIf(!supportsReferenceFiles)(
+test.runIf(supportsReferenceFiles)(
 	'should still error when layer is declared and not used anywhere including referenceFiles',
 	async () => {
 		const file = write_fixture('utilities.css', '@layer other { .u-flex { display: flex; } }')

--- a/src/rules/no-unused-layers/index.test.ts
+++ b/src/rules/no-unused-layers/index.test.ts
@@ -1,31 +1,9 @@
 import stylelint from 'stylelint'
-import { test, expect, afterEach } from 'vitest'
-import fs from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
+import { test, expect } from 'vitest'
 import plugin, { rule_name } from './index.js'
+import { supportsReferenceFiles, createFixtures } from '../test-utils.js'
 
-import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
-const [major, minor] = stylelintPkg.version.split('.').map(Number)
-const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
-
-let tmp_dir: string
-
-function write_fixture(name: string, content: string): string {
-	if (!tmp_dir) {
-		tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-unused-layers-test-'))
-	}
-	const file_path = path.join(tmp_dir, name)
-	fs.writeFileSync(file_path, content, 'utf8')
-	return file_path
-}
-
-afterEach(() => {
-	if (tmp_dir) {
-		fs.rmSync(tmp_dir, { recursive: true, force: true })
-		tmp_dir = undefined!
-	}
-})
+const write_fixture = createFixtures('no-unused-layers-test-')
 
 test('should not error when a declared layer is defined in a block', async () => {
 	const config = {

--- a/src/rules/no-unused-layers/index.ts
+++ b/src/rules/no-unused-layers/index.ts
@@ -72,6 +72,29 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 			}
 		})
 
+		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
+		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
+		for (const refRoot of referenceRoots) {
+			refRoot.walkAtRules('layer', (atRule) => {
+				if (atRule.nodes !== undefined) {
+					const name = atRule.params.trim()
+					if (name) {
+						tracker.use(name)
+						mark_ancestors_used(name, tracker)
+					}
+				}
+			})
+			refRoot.walkAtRules('import', (atRule) => {
+				const parsed = parse_atrule_prelude('import', atRule.params)
+				for (const child of parsed) {
+					if (child.type === LAYER_NAME && child.name) {
+						tracker.use(child.name)
+						mark_ancestors_used(child.name, tracker)
+					}
+				}
+			})
+		}
+
 		for (const [layer, node] of tracker.unused()) {
 			if (secondaryOptions?.ignore && is_allowed(layer, secondaryOptions.ignore)) {
 				continue

--- a/src/rules/no-unused-layers/index.ts
+++ b/src/rules/no-unused-layers/index.ts
@@ -74,8 +74,8 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 
 		// referenceRoots is available in stylelint >=17.9.0; undefined in older versions
 		const referenceRoots = (result.stylelint.referenceRoots as Root[] | undefined) ?? []
-		for (const refRoot of referenceRoots) {
-			refRoot.walkAtRules('layer', (atRule) => {
+		for (const referenceRoot of referenceRoots) {
+			referenceRoot.walkAtRules('layer', (atRule) => {
 				if (atRule.nodes !== undefined) {
 					const name = atRule.params.trim()
 					if (name) {
@@ -84,7 +84,7 @@ const ruleFunction = (primaryOptions: true, secondaryOptions?: SecondaryOptions)
 					}
 				}
 			})
-			refRoot.walkAtRules('import', (atRule) => {
+			referenceRoot.walkAtRules('import', (atRule) => {
 				const parsed = parse_atrule_prelude('import', atRule.params)
 				for (const child of parsed) {
 					if (child.type === LAYER_NAME && child.name) {

--- a/src/rules/test-utils.ts
+++ b/src/rules/test-utils.ts
@@ -1,0 +1,28 @@
+import { afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import stylelintPkg from 'stylelint/package.json' with { type: 'json' }
+
+const [major, minor] = stylelintPkg.version.split('.').map(Number)
+export const supportsReferenceFiles = major > 17 || (major === 17 && minor >= 9)
+
+export function createFixtures(prefix: string): (name: string, content: string) => string {
+	let tmp_dir: string | undefined
+
+	afterEach(() => {
+		if (tmp_dir) {
+			fs.rmSync(tmp_dir, { recursive: true, force: true })
+			tmp_dir = undefined
+		}
+	})
+
+	return function write_fixture(name: string, content: string): string {
+		if (!tmp_dir) {
+			tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+		}
+		const file_path = path.join(tmp_dir, name)
+		fs.writeFileSync(file_path, content, 'utf8')
+		return file_path
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds support for stylelint's `referenceFiles` configuration option (available in stylelint >=17.9.0) across all plugin rules. This allows rules to consider declarations and usages from external CSS files when validating the current file.

## Key Changes

- **Test Infrastructure**: Added common test utilities to all rule test files:
  - Temporary directory management for creating fixture files
  - Version detection to conditionally run referenceFiles tests only on compatible stylelint versions
  - `write_fixture()` helper function for creating test CSS files
  - `afterEach()` cleanup to remove temporary directories

- **Rule Implementation Updates**: Modified all six rules to process `referenceRoots` from stylelint:
  - `no-unused-keyframes`: Checks animation usage in reference files
  - `no-unused-layers`: Checks layer usage in reference files
  - `no-unused-custom-properties`: Checks custom property usage in reference files
  - `no-unused-container-names`: Checks container query usage in reference files
  - `no-unknown-custom-properties`: Checks custom property declarations in reference files
  - `no-unknown-container-names`: Checks container name declarations in reference files

- **Code Refactoring**: Extracted common collection logic into reusable functions:
  - `collect_container_names()` in no-unknown-container-names
  - `collect_declared_properties()` in no-unknown-custom-properties

- **Test Coverage**: Added comprehensive test cases for each rule covering:
  - Successful validation when declarations are used in reference files
  - Continued error reporting when declarations are unused even with reference files

- **CI Updates**: Extended test matrix to include stylelint 17.0 for better version coverage

## Implementation Details

All rules follow the same pattern:
1. Check if `result.stylelint.referenceRoots` exists (gracefully handles older stylelint versions)
2. Iterate through reference file ASTs and collect declarations/usages
3. Merge findings with main file analysis before reporting errors

This ensures backward compatibility while enabling the new functionality for users on stylelint >=17.9.0.

https://claude.ai/code/session_01QZtigugctRpvnNvebRNaZG