### PR TITLE
PoC: Stop importing bare `stylelint` in rule files

### DIFF
--- a/src/rules/max-atrules/index.ts
+++ b/src/rules/max-atrules/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_non_negative_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-atrules'
 

--- a/src/rules/max-average-declarations-per-rule/index.ts
+++ b/src/rules/max-average-declarations-per-rule/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-average-declarations-per-rule'
 

--- a/src/rules/max-average-selector-complexity/index.ts
+++ b/src/rules/max-average-selector-complexity/index.ts
@@ -1,11 +1,10 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_selector_list } from '@projectwallace/css-parser/parse-selector'
 import { getComplexity } from '@projectwallace/css-analyzer/selectors'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
 import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-average-selector-complexity'
 

--- a/src/rules/max-average-selector-specificity/index.ts
+++ b/src/rules/max-average-selector-specificity/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { getSpecificity, compareSpecificity } from '@projectwallace/css-analyzer/selectors'
 import type { Specificity } from '@projectwallace/css-analyzer'
 import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-average-selector-specificity'
 

--- a/src/rules/max-average-selectors-per-rule/index.ts
+++ b/src/rules/max-average-selectors-per-rule/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_selector_list } from '@projectwallace/css-parser/parse-selector'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
 import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-average-selectors-per-rule'
 

--- a/src/rules/max-comment-size/index.ts
+++ b/src/rules/max-comment-size/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_non_negative_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-comment-size'
 

--- a/src/rules/max-comments/index.ts
+++ b/src/rules/max-comments/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_non_negative_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-comments'
 

--- a/src/rules/max-declarations-per-rule/index.ts
+++ b/src/rules/max-declarations-per-rule/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-declarations-per-rule'
 

--- a/src/rules/max-declarations/index.ts
+++ b/src/rules/max-declarations/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_non_negative_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-declarations'
 

--- a/src/rules/max-embedded-content-size/index.ts
+++ b/src/rules/max-embedded-content-size/index.ts
@@ -1,11 +1,10 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { walk } from '@projectwallace/css-parser/walker'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { is_url } from '@projectwallace/css-parser'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-embedded-content-size'
 

--- a/src/rules/max-file-size/index.ts
+++ b/src/rules/max-file-size/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-file-size'
 

--- a/src/rules/max-important-ratio/index.ts
+++ b/src/rules/max-important-ratio/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_ratio } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-important-ratio'
 

--- a/src/rules/max-lines-of-code/index.ts
+++ b/src/rules/max-lines-of-code/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-lines-of-code'
 

--- a/src/rules/max-rules/index.ts
+++ b/src/rules/max-rules/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_non_negative_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-rules'
 

--- a/src/rules/max-selector-complexity/index.ts
+++ b/src/rules/max-selector-complexity/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_selector_list } from '@projectwallace/css-parser/parse-selector'
 import { getComplexity } from '@projectwallace/css-analyzer/selectors'
 import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-selector-complexity'
 

--- a/src/rules/max-selectors-per-rule/index.ts
+++ b/src/rules/max-selectors-per-rule/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_selector_list } from '@projectwallace/css-parser/parse-selector'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
 import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-selectors-per-rule'
 

--- a/src/rules/max-selectors/index.ts
+++ b/src/rules/max-selectors/index.ts
@@ -1,9 +1,8 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Rule } from 'postcss'
 import { is_valid_non_negative_integer } from '../../utils/option-validators.js'
 import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-selectors'
 

--- a/src/rules/max-spacing-resets/index.ts
+++ b/src/rules/max-spacing-resets/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { isValueReset } from '@projectwallace/css-analyzer/values'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { is_valid_non_negative_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 export const rule_name = 'projectwallace/max-spacing-resets'
 

--- a/src/rules/max-unique-animation-functions/index.ts
+++ b/src/rules/max-unique-animation-functions/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import {
 	is_allowed,
@@ -8,8 +9,6 @@ import {
 import { analyzeAnimation } from '@projectwallace/css-analyzer/values'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { OPERATOR } from '@projectwallace/css-parser'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-animation-functions'
 

--- a/src/rules/max-unique-box-shadows/index.ts
+++ b/src/rules/max-unique-box-shadows/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { keywords } from '@projectwallace/css-analyzer/values'
 import {
@@ -6,8 +7,6 @@ import {
 	ignore_option_validators,
 	is_valid_positive_integer,
 } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-box-shadows'
 

--- a/src/rules/max-unique-color-formats/index.ts
+++ b/src/rules/max-unique-color-formats/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
 import { parse_value } from '@projectwallace/css-parser'
 import { collect_colors, COLOR_PROPERTIES } from '../../utils/collect-colors.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-color-formats'
 

--- a/src/rules/max-unique-colors/index.ts
+++ b/src/rules/max-unique-colors/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import {
 	is_allowed,
@@ -7,8 +8,6 @@ import {
 } from '../../utils/option-validators.js'
 import { parse_value } from '@projectwallace/css-parser'
 import { collect_colors, COLOR_PROPERTIES } from '../../utils/collect-colors.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-colors'
 

--- a/src/rules/max-unique-durations/index.ts
+++ b/src/rules/max-unique-durations/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import {
 	is_allowed,
@@ -8,8 +9,6 @@ import {
 import { analyzeAnimation, keywords } from '@projectwallace/css-analyzer/values'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { OPERATOR } from '@projectwallace/css-parser'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-durations'
 

--- a/src/rules/max-unique-font-families/index.ts
+++ b/src/rules/max-unique-font-families/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration, AtRule } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { destructureFontShorthand, keywords } from '@projectwallace/css-analyzer/values'
@@ -7,8 +8,6 @@ import {
 	ignore_option_validators,
 	is_valid_non_negative_integer,
 } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-font-families'
 

--- a/src/rules/max-unique-font-sizes/index.ts
+++ b/src/rules/max-unique-font-sizes/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { destructureFontShorthand, keywords } from '@projectwallace/css-analyzer/values'
@@ -7,8 +8,6 @@ import {
 	ignore_option_validators,
 	is_valid_non_negative_integer,
 } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-font-sizes'
 

--- a/src/rules/max-unique-gradients/index.ts
+++ b/src/rules/max-unique-gradients/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { walk } from '@projectwallace/css-parser/walker'
@@ -8,8 +9,6 @@ import {
 	is_valid_positive_integer,
 } from '../../utils/option-validators.js'
 import { is_function } from '@projectwallace/css-parser'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-gradients'
 

--- a/src/rules/max-unique-keyframes/index.ts
+++ b/src/rules/max-unique-keyframes/index.ts
@@ -1,12 +1,11 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, AtRule } from 'postcss'
 import {
 	is_allowed,
 	ignore_option_validators,
 	is_valid_non_negative_integer,
 } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-keyframes'
 

--- a/src/rules/max-unique-line-heights/index.ts
+++ b/src/rules/max-unique-line-heights/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { destructureFontShorthand, keywords } from '@projectwallace/css-analyzer/values'
@@ -7,8 +8,6 @@ import {
 	ignore_option_validators,
 	is_valid_non_negative_integer,
 } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-line-heights'
 

--- a/src/rules/max-unique-media-queries/index.ts
+++ b/src/rules/max-unique-media-queries/index.ts
@@ -1,12 +1,11 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, AtRule } from 'postcss'
 import {
 	is_allowed,
 	ignore_option_validators,
 	is_valid_non_negative_integer,
 } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-media-queries'
 

--- a/src/rules/max-unique-supports-queries/index.ts
+++ b/src/rules/max-unique-supports-queries/index.ts
@@ -1,12 +1,11 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, AtRule } from 'postcss'
 import {
 	is_allowed,
 	ignore_option_validators,
 	is_valid_non_negative_integer,
 } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-supports-queries'
 

--- a/src/rules/max-unique-text-shadows/index.ts
+++ b/src/rules/max-unique-text-shadows/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { keywords } from '@projectwallace/css-analyzer/values'
 import {
@@ -6,8 +7,6 @@ import {
 	ignore_option_validators,
 	is_valid_positive_integer,
 } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-text-shadows'
 

--- a/src/rules/max-unique-units/index.ts
+++ b/src/rules/max-unique-units/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { walk, DIMENSION } from '@projectwallace/css-parser'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { is_valid_positive_integer } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-units'
 

--- a/src/rules/max-unique-z-indexes/index.ts
+++ b/src/rules/max-unique-z-indexes/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { walk, NUMBER } from '@projectwallace/css-parser'
@@ -7,8 +8,6 @@ import {
 	ignore_option_validators,
 	is_valid_non_negative_integer,
 } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/max-unique-z-indexes'
 

--- a/src/rules/min-declaration-uniqueness-ratio/index.ts
+++ b/src/rules/min-declaration-uniqueness-ratio/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_ratio } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/min-declaration-uniqueness-ratio'
 

--- a/src/rules/min-selector-uniqueness-ratio/index.ts
+++ b/src/rules/min-selector-uniqueness-ratio/index.ts
@@ -1,9 +1,8 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_valid_ratio } from '../../utils/option-validators.js'
 import { is_keyframe_rule } from '../../utils/is-keyframe-rule.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/min-selector-uniqueness-ratio'
 

--- a/src/rules/no-anonymous-layers/index.ts
+++ b/src/rules/no-anonymous-layers/index.ts
@@ -1,9 +1,8 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { LAYER_NAME } from '@projectwallace/css-parser/nodes'
 import { parse_atrule_prelude } from '@projectwallace/css-parser/parse-atrule-prelude'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-anonymous-layers'
 

--- a/src/rules/no-atrule-browserhacks/index.ts
+++ b/src/rules/no-atrule-browserhacks/index.ts
@@ -1,9 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { isSupportsBrowserhack, isMediaBrowserhack } from '@projectwallace/css-analyzer/atrules'
 import { parse_atrule_prelude } from '@projectwallace/css-parser/parse-atrule-prelude'
 
-const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/no-atrule-browserhacks'
 
 const messages = utils.ruleMessages(rule_name, {

--- a/src/rules/no-duplicate-anchor-names/index.ts
+++ b/src/rules/no-duplicate-anchor-names/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { IDENTIFIER } from '@projectwallace/css-parser/nodes'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { keywords } from '@projectwallace/css-analyzer/values'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-duplicate-anchor-names'
 

--- a/src/rules/no-duplicate-container-names/index.ts
+++ b/src/rules/no-duplicate-container-names/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { IDENTIFIER, OPERATOR } from '@projectwallace/css-parser/nodes'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { keywords } from '@projectwallace/css-analyzer/values'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-duplicate-container-names'
 

--- a/src/rules/no-duplicate-custom-properties/index.ts
+++ b/src/rules/no-duplicate-custom-properties/index.ts
@@ -1,7 +1,6 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-duplicate-custom-properties'
 

--- a/src/rules/no-duplicate-data-urls/index.ts
+++ b/src/rules/no-duplicate-data-urls/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { URL as CSS_URL } from '@projectwallace/css-parser/nodes'
 import { walk } from '@projectwallace/css-parser/walker'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-duplicate-data-urls'
 

--- a/src/rules/no-duplicate-keyframes/index.ts
+++ b/src/rules/no-duplicate-keyframes/index.ts
@@ -1,8 +1,7 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { keywords } from '@projectwallace/css-analyzer/values'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-duplicate-keyframes'
 

--- a/src/rules/no-duplicate-registered-properties/index.ts
+++ b/src/rules/no-duplicate-registered-properties/index.ts
@@ -1,7 +1,6 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-duplicate-registered-properties'
 

--- a/src/rules/no-invalid-z-index/index.ts
+++ b/src/rules/no-invalid-z-index/index.ts
@@ -1,9 +1,8 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { walk, NUMBER } from '@projectwallace/css-parser'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-invalid-z-index'
 

--- a/src/rules/no-property-browserhacks/index.ts
+++ b/src/rules/no-property-browserhacks/index.ts
@@ -1,7 +1,6 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-property-browserhacks'
 

--- a/src/rules/no-property-shorthand/index.ts
+++ b/src/rules/no-property-shorthand/index.ts
@@ -1,10 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { parse_value } from '@projectwallace/css-parser'
 import { shorthand_properties } from '@projectwallace/css-analyzer/properties'
 import { is_allowed, ignore_option_validators } from '../../utils/option-validators.js'
-
-const { createPlugin, utils } = stylelint
 
 export const rule_name = 'projectwallace/no-property-shorthand'
 

--- a/src/rules/no-pseudo-elements-in-is-where/index.ts
+++ b/src/rules/no-pseudo-elements-in-is-where/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import {
 	walk,
@@ -8,7 +9,6 @@ import {
 	is_pseudo_element_selector,
 } from '@projectwallace/css-parser'
 
-const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/no-pseudo-elements-in-is-where'
 
 const messages = utils.ruleMessages(rule_name, {

--- a/src/rules/no-static-container-queries/index.ts
+++ b/src/rules/no-static-container-queries/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import {
 	parse_atrule_prelude,
@@ -11,8 +12,6 @@ import {
 	is_prelude_operator,
 	type MediaFeature,
 } from '@projectwallace/css-parser'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-static-container-queries'
 

--- a/src/rules/no-static-media-queries/index.ts
+++ b/src/rules/no-static-media-queries/index.ts
@@ -1,11 +1,10 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { MEDIA_QUERY, MEDIA_FEATURE, PRELUDE_OPERATOR } from '@projectwallace/css-parser/nodes'
 import { parse_atrule_prelude } from '@projectwallace/css-parser/parse-atrule-prelude'
 import { walk, BREAK } from '@projectwallace/css-parser/walker'
 import { is_dimension, is_number } from '@projectwallace/css-parser'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-static-media-queries'
 

--- a/src/rules/no-unknown-container-names/index.ts
+++ b/src/rules/no-unknown-container-names/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { IDENTIFIER, OPERATOR } from '@projectwallace/css-parser/nodes'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
@@ -22,8 +23,6 @@ function collect_container_names(root: Root, declared: Set<string>): void {
 		}
 	})
 }
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-unknown-container-names'
 

--- a/src/rules/no-unreachable-media-conditions/index.ts
+++ b/src/rules/no-unreachable-media-conditions/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, AtRule } from 'postcss'
 import {
 	MEDIA_QUERY,
@@ -29,8 +30,6 @@ function cartesian<T>(arrays: T[][]): T[][] {
 	}
 	return result
 }
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-unreachable-media-conditions'
 

--- a/src/rules/no-unused-container-names/index.ts
+++ b/src/rules/no-unused-container-names/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration } from 'postcss'
 import { IDENTIFIER, OPERATOR } from '@projectwallace/css-parser/nodes'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
@@ -6,8 +7,6 @@ import { parse_atrule_prelude } from '@projectwallace/css-parser/parse-atrule-pr
 import { keywords } from '@projectwallace/css-analyzer/values'
 import { is_allowed } from '../../utils/option-validators.js'
 import { DefinedUsed } from '../../utils/defined-used.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-unused-container-names'
 

--- a/src/rules/no-unused-custom-properties/index.ts
+++ b/src/rules/no-unused-custom-properties/index.ts
@@ -1,4 +1,5 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, Declaration, AtRule } from 'postcss'
 import { FUNCTION, IDENTIFIER } from '@projectwallace/css-parser/nodes'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
@@ -7,8 +8,6 @@ import { is_allowed } from '../../utils/option-validators.js'
 import { collect_usages_from_files } from '../../utils/import-from.js'
 import type { ImportFrom } from '../../utils/import-from.js'
 import { DefinedUsed } from '../../utils/defined-used.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-unused-custom-properties'
 

--- a/src/rules/no-unused-keyframes/index.ts
+++ b/src/rules/no-unused-keyframes/index.ts
@@ -1,12 +1,11 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, AtRule } from 'postcss'
 import { analyzeAnimation } from '@projectwallace/css-analyzer/values'
 import { IDENTIFIER, STRING } from '@projectwallace/css-parser/nodes'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 import { is_allowed } from '../../utils/option-validators.js'
 import { DefinedUsed } from '../../utils/defined-used.js'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-unused-keyframes'
 

--- a/src/rules/no-unused-layers/index.ts
+++ b/src/rules/no-unused-layers/index.ts
@@ -1,11 +1,10 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root, AtRule } from 'postcss'
 import { LAYER_NAME } from '@projectwallace/css-parser/nodes'
 import { parse_atrule_prelude } from '@projectwallace/css-parser/parse-atrule-prelude'
 import { is_allowed } from '../../utils/option-validators.js'
 import { DefinedUsed } from '../../utils/defined-used.js'
-
-const { createPlugin, utils } = stylelint
 
 export const rule_name = 'projectwallace/no-unused-layers'
 

--- a/src/rules/no-useless-custom-property-assignment/index.ts
+++ b/src/rules/no-useless-custom-property-assignment/index.ts
@@ -1,11 +1,10 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { is_allowed } from '../../utils/option-validators.js'
 import { FUNCTION, IDENTIFIER } from '@projectwallace/css-parser/nodes'
 import { BREAK, walk } from '@projectwallace/css-parser/walker'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
-
-const { createPlugin, utils } = stylelint
 
 const rule_name = 'projectwallace/no-useless-custom-property-assignment'
 

--- a/src/rules/no-value-browserhacks/index.ts
+++ b/src/rules/no-value-browserhacks/index.ts
@@ -1,9 +1,9 @@
-import stylelint from 'stylelint'
+import { createPlugin, utils } from '../../utils/stylelint.js'
+import type stylelint from 'stylelint'
 import type { Root } from 'postcss'
 import { isValueBrowserhack } from '@projectwallace/css-analyzer/values'
 import { parse_value } from '@projectwallace/css-parser/parse-value'
 
-const { createPlugin, utils } = stylelint
 const rule_name = 'projectwallace/no-value-browserhacks'
 
 const messages = utils.ruleMessages(rule_name, {

--- a/src/utils/stylelint-internals.d.ts
+++ b/src/utils/stylelint-internals.d.ts
@@ -1,0 +1,28 @@
+// `report`, `ruleMessages` and `validateOptions` live under stylelint's
+// public `./lib/utils/*` export, but TypeScript's "bundler" resolution stops
+// falling back to plain JS inference for them because stylelint's main entry
+// carries a "types" condition (making TS treat the whole package as
+// self-typed, so every subpath needs its own declaration). Re-check these
+// shapes against node_modules/stylelint/lib/utils/*.mjs whenever the
+// `stylelint` peer range in package.json changes.
+
+declare module 'stylelint/lib/utils/report.mjs' {
+	import type { Problem } from 'stylelint'
+	export default function report(problem: Problem): void
+}
+
+declare module 'stylelint/lib/utils/ruleMessages.mjs' {
+	export default function ruleMessages<T extends Record<string, unknown>>(
+		ruleName: string,
+		messages: T,
+	): T
+}
+
+declare module 'stylelint/lib/utils/validateOptions.mjs' {
+	import type { PostcssResult } from 'stylelint'
+	export default function validateOptions(
+		result: PostcssResult,
+		ruleName: string,
+		...optionDescriptions: unknown[]
+	): boolean
+}

--- a/src/utils/stylelint.ts
+++ b/src/utils/stylelint.ts
@@ -1,0 +1,18 @@
+// Rules only ever need `createPlugin` and a few `utils` functions off the
+// `stylelint` package, but importing the bare package (`import stylelint from
+// 'stylelint'`) pulls in `standalone.mjs` and everything behind it (globby,
+// cosmiconfig, write-file-atomic, ...), which don't bundle for non-Node
+// targets like the browser. `createPlugin` is trivial to reimplement, and the
+// three `utils` functions actually used live under stylelint's public
+// `./lib/utils/*` export, so importing them directly avoids the bare
+// specifier entirely.
+import report from 'stylelint/lib/utils/report.mjs'
+import ruleMessages from 'stylelint/lib/utils/ruleMessages.mjs'
+import validateOptions from 'stylelint/lib/utils/validateOptions.mjs'
+import type { Rule } from 'stylelint'
+
+export function createPlugin(ruleName: string, rule: Rule) {
+	return { ruleName, rule }
+}
+
+export const utils = { report, ruleMessages, validateOptions }


### PR DESCRIPTION
## Summary

- Every rule only used the bare `stylelint` default export (`import stylelint from 'stylelint'`) to reach `createPlugin` and three `utils` functions (`report`, `ruleMessages`, `validateOptions`). That default export resolves to stylelint's main entry point, which statically pulls in `standalone.mjs` and everything behind it (`globby`, `cosmiconfig`, `write-file-atomic`, ...) — fine for stylelint's own CLI, but dead weight for anyone deep-importing these rule modules.
- This came up while getting stylelint's linting core running **in the browser** (projectwallace/projectwallace.com#367): none of those Node-only deps bundle for the browser, so the app had to alias the bare `stylelint` specifier to a hand-rolled shim just to work around this package. With this change that shim is no longer necessary — the plugin is browser-safe by construction.
- `createPlugin` is a two-line function, and the three `utils` functions actually used live under stylelint's public `./lib/utils/*` export. `src/utils/stylelint.ts` now re-implements/re-exports just those directly, and every rule imports from there instead of `stylelint`.
- Verified the deep-imported `lib/utils/*` paths exist in both stylelint 16 and 17 (the peer range).

## Test plan

- [x] `npx vitest run` — 921 tests pass, unchanged
- [x] `npx tsc --noEmit` — clean (added `src/utils/stylelint-internals.d.ts` for the deep `lib/utils/*` imports, same reasoning as stylelint's own `.d.ts` pinning)
- [x] `npx oxlint -D perf` / `npx oxfmt --check` — clean
- [x] `npx tsdown` + `publint` — clean build; confirmed `dist/**/*.mjs` no longer contains any `from "stylelint"` bare import
- [x] Smoke-ran the built package through the real `stylelint.lint()` against known-bad CSS — same warnings as before

---
_Generated by [Claude Code](https://claude.ai/code/session_015YSKEQXzpmfmag1HcDNUaQ)_